### PR TITLE
Hotfix/329 info bar styling

### DIFF
--- a/src/pages/Header/InformationBar/InformationBar.js
+++ b/src/pages/Header/InformationBar/InformationBar.js
@@ -9,18 +9,12 @@ import {
   // Chip,
   Dialog, DialogActions, DialogContent, Grid, Typography,
 } from '@mui/material';
-import {
-  LocationOn,
-  // , Refresh
-} from '@mui/icons-material';
+import { LocationOn } from '@mui/icons-material';
 import CloudIcon from '@mui/icons-material/Cloud';
 import CheckIcon from '@mui/icons-material/Check';
 import FilterHdrIcon from '@mui/icons-material/FilterHdr';
 import React, { useContext, useState } from 'react';
-import {
-  BinaryButton,
-  // LightButton,
-} from '../../../shared/constants';
+import { BinaryButton } from '../../../shared/constants';
 import { Context } from '../../../store/Store';
 import '../../../styles/greenBar.scss';
 import LocationComponent from '../../Location/Location';
@@ -124,8 +118,11 @@ const InformationBar = () => {
   };
 
   const getData = (type) => {
-    // eslint-disable-next-line max-len
-    if ((state.soilData.Flooding_Frequency === null && type === 'soil') || (type === 'address' && state.address === '') || (type === 'weather' && state.weatherData.length === 0)) {
+    if (
+      (state.soilData.Flooding_Frequency === null && type === 'soil')
+      || (type === 'address' && state.address === '')
+      || (type === 'weather' && state.weatherData.length === 0)
+    ) {
       return '';
     }
 

--- a/src/pages/Header/InformationBar/InformationBar.js
+++ b/src/pages/Header/InformationBar/InformationBar.js
@@ -57,7 +57,7 @@ const InformationBar = () => {
 
     dispatch({
       type: 'GOTO_PROGRESS',
-      data: progress,
+      data: { progress },
     });
   };
 

--- a/src/pages/Header/InformationBar/InformationBar.js
+++ b/src/pages/Header/InformationBar/InformationBar.js
@@ -7,7 +7,7 @@
 import {
   Button,
   // Chip,
-  Dialog, DialogActions, DialogContent, Grid, Typography,
+  Dialog, DialogActions, DialogContent, Grid, Tooltip, Typography,
 } from '@mui/material';
 import { LocationOn } from '@mui/icons-material';
 import CloudIcon from '@mui/icons-material/Cloud';
@@ -68,14 +68,29 @@ const InformationBar = () => {
     });
   };
 
+  const getSelectedValues = (type) => {
+    switch (type) {
+      case 'location':
+        return `Zone ${state.zone}`;
+      case 'soil':
+        return state.soilData.Drainage_Class
+          .toString()
+          .split(',')
+          .join(', ');
+      case 'weather':
+        return `${state.weatherData.averageFrost.firstFrostDate.month} ${state.weatherData.averageFrost.firstFrostDate.day}`;
+      default: return '';
+    }
+  };
+
   const getIconInfo = (type) => {
     if (type === 'location') {
       return (
         <>
           <LocationOn />
-            &nbsp;Location: Zone
+            &nbsp;Location:
           {' '}
-          {state.zone}
+          {getSelectedValues('location')}
         </>
       );
     }
@@ -87,9 +102,7 @@ const InformationBar = () => {
             &nbsp;
           {' '}
           {/* {`Soils: Map Unit Name (${state.soilData.Map_Unit_Name}%), Drainage Class: ${state.soilData.Drainage_Class}})`} */}
-          {`Soil Drainage: ${state.soilData.Drainage_Class.toString()
-            .split(',')
-            .join(', ')}`}
+          {`Soil Drainage: ${getSelectedValues('soil')}`}
         </>
       );
     }
@@ -100,7 +113,7 @@ const InformationBar = () => {
           <CloudIcon fontSize="small" />
             &nbsp;
           {' '}
-          {`First Frost: ${state.weatherData.averageFrost.firstFrostDate.month} ${state.weatherData.averageFrost.firstFrostDate.day}`}
+          {`First Frost: ${getSelectedValues('weather')}`}
         </>
       );
     }
@@ -185,16 +198,24 @@ const InformationBar = () => {
           container
         >
           <Grid item xs={12} sm={6} md={6} lg={1.5}>
-            {getData('location')}
+            <Tooltip title={getSelectedValues('location')} placement="bottom">
+              {getData('location')}
+            </Tooltip>
           </Grid>
           <Grid item xs={12} sm={6} md={6} lg={3.5}>
-            {getData('soil')}
+            <Tooltip title={getSelectedValues('soil')} placement="bottom">
+              {getData('soil')}
+            </Tooltip>
           </Grid>
           <Grid item xs={12} sm={6} md={6} lg={2.5}>
-            {getData('weather')}
+            <Tooltip title={getSelectedValues('weather')} placement="bottom">
+              {getData('weather')}
+            </Tooltip>
           </Grid>
           <Grid item xs={12} sm={6} md={6} lg={1.5}>
-            {getData('goals')}
+            <Tooltip title={getSelectedValues('goals')} placement="bottom">
+              {getData('goals')}
+            </Tooltip>
           </Grid>
           <Grid
             item

--- a/src/pages/Header/InformationBar/InformationBar.js
+++ b/src/pages/Header/InformationBar/InformationBar.js
@@ -181,26 +181,28 @@ const InformationBar = () => {
     <div className="greenBarParent" id="greenBarParent">
       <div className="greenBarWrapper">
         {state.progress > 0 && window.location.pathname === speciesSelectorToolName && (
-        <Grid container>
-          <Grid item xs={12} sm={6} md={2.4}>
+        <Grid
+          container
+        >
+          <Grid item xs={12} sm={6} md={6} lg={1.5}>
             {getData('location')}
           </Grid>
-          <Grid item xs={12} sm={6} md={2.4}>
+          <Grid item xs={12} sm={6} md={6} lg={3.5}>
             {getData('soil')}
           </Grid>
-          <Grid item xs={12} sm={6} md={2.4}>
+          <Grid item xs={12} sm={6} md={6} lg={2.5}>
             {getData('weather')}
           </Grid>
-          <Grid item xs={12} sm={6} md={2.4}>
+          <Grid item xs={12} sm={6} md={6} lg={1.5}>
             {getData('goals')}
           </Grid>
           <Grid
             item
             xs={12}
             sm={12}
-            md={2.4}
+            md={12}
+            lg={2.5}
           >
-
             <ProgressButtons closeExpansionPanel={closeExpansionPanel} setConfirmationOpen={setConfirmationOpen} />
           </Grid>
         </Grid>

--- a/src/pages/Header/InformationBar/InformationBar.js
+++ b/src/pages/Header/InformationBar/InformationBar.js
@@ -5,9 +5,7 @@
 */
 
 import {
-  Button,
-  // Chip,
-  Dialog, DialogActions, DialogContent, Grid, Tooltip, Typography,
+  Button, Dialog, DialogActions, DialogContent, Grid, Tooltip, Typography,
 } from '@mui/material';
 import { LocationOn } from '@mui/icons-material';
 import CloudIcon from '@mui/icons-material/Cloud';
@@ -48,23 +46,18 @@ const InformationBar = () => {
   };
 
   const handleBtnClick = (type) => {
-    let progress;
+    const options = {
+      location: 1,
+      soil: 2,
+      weather: 3,
+      goals: 4,
+    };
 
-    if (type === 'location') {
-      progress = 1;
-    } else if (type === 'soil') {
-      progress = 2;
-    } else if (type === 'weather') {
-      progress = 3;
-    } else if (type === 'goals') {
-      progress = 4;
-    }
+    const progress = options[type];
 
     dispatch({
       type: 'GOTO_PROGRESS',
-      data: {
-        progress,
-      },
+      data: progress,
     });
   };
 
@@ -84,50 +77,43 @@ const InformationBar = () => {
   };
 
   const getIconInfo = (type) => {
-    if (type === 'location') {
-      return (
-        <>
-          <LocationOn />
+    switch (type) {
+      case 'location':
+        return (
+          <>
+            <LocationOn />
             &nbsp;Location:
-          {' '}
-          {getSelectedValues('location')}
-        </>
-      );
-    }
-
-    if (type === 'soil') {
-      return (
+            {' '}
+            {getSelectedValues('location')}
+          </>
+        );
+      case 'soil': return (
         <>
           <FilterHdrIcon />
-            &nbsp;
+          &nbsp;
           {' '}
           {/* {`Soils: Map Unit Name (${state.soilData.Map_Unit_Name}%), Drainage Class: ${state.soilData.Drainage_Class}})`} */}
           {`Soil Drainage: ${getSelectedValues('soil')}`}
         </>
       );
-    }
-
-    if (type === 'weather') {
-      return (
-        <>
-          <CloudIcon fontSize="small" />
+      case 'weather':
+        return (
+          <>
+            <CloudIcon fontSize="small" />
             &nbsp;
-          {' '}
-          {`First Frost: ${getSelectedValues('weather')}`}
-        </>
-      );
-    }
-
-    if (type === 'goals') {
-      return (
-        <>
-          <CheckIcon />
+            {' '}
+            {`First Frost: ${getSelectedValues('weather')}`}
+          </>
+        );
+      case 'goals':
+        return (
+          <>
+            <CheckIcon />
             &nbsp;Goals
-        </>
-      );
+          </>
+        );
+      default: return null;
     }
-
-    return '';
   };
 
   const getData = (type) => {

--- a/src/pages/Header/InformationBar/InformationBar.js
+++ b/src/pages/Header/InformationBar/InformationBar.js
@@ -5,15 +5,21 @@
 */
 
 import {
-  Button, Dialog, DialogActions, DialogContent, Typography,
+  Button,
+  // Chip,
+  Dialog, DialogActions, DialogContent, Grid, Typography,
 } from '@mui/material';
-import { LocationOn, Refresh } from '@mui/icons-material';
+import {
+  LocationOn,
+  // , Refresh
+} from '@mui/icons-material';
 import CloudIcon from '@mui/icons-material/Cloud';
 import CheckIcon from '@mui/icons-material/Check';
 import FilterHdrIcon from '@mui/icons-material/FilterHdr';
 import React, { useContext, useState } from 'react';
 import {
-  BinaryButton, LightButton,
+  BinaryButton,
+  // LightButton,
 } from '../../../shared/constants';
 import { Context } from '../../../store/Store';
 import '../../../styles/greenBar.scss';
@@ -178,54 +184,29 @@ const InformationBar = () => {
     <div className="greenBarParent" id="greenBarParent">
       <div className="greenBarWrapper">
         {state.progress > 0 && window.location.pathname === speciesSelectorToolName && (
-        <>
-          <div>
+        <Grid container>
+          <Grid item xs={12} sm={6} md={2.4}>
             {getData('location')}
-          </div>
-          <div>
+          </Grid>
+          <Grid item xs={12} sm={6} md={2.4}>
             {getData('soil')}
-          </div>
-          <div>
+          </Grid>
+          <Grid item xs={12} sm={6} md={2.4}>
             {getData('weather')}
-          </div>
-          <div>
+          </Grid>
+          <Grid item xs={12} sm={6} md={2.4}>
             {getData('goals')}
-          </div>
-          <div
-            style={{
-              marginRight: '40px',
-            }}
-            className="restartBtnWrapper"
+          </Grid>
+          <Grid
+            item
+            xs={12}
+            sm={12}
+            md={2.4}
           >
-            <ProgressButtons />
-            <LightButton
-              style={{
-                maxWidth: '90px',
-                maxHeight: '35px',
-                minWidth: '90px',
-                minHeight: '35px',
-                fontSize: '13px',
-                marginLeft: '-5%',
-                marginTop: '2.5px',
-                marginBottom: '2.5px',
 
-              }}
-              onClick={() => {
-                closeExpansionPanel();
-                setConfirmationOpen(true);
-              }}
-            >
-              <Refresh />
-              <p style={{
-                paddingBottom: '6px',
-              }}
-              >
-                &nbsp; Restart
-
-              </p>
-            </LightButton>
-          </div>
-        </>
+            <ProgressButtons closeExpansionPanel={closeExpansionPanel} setConfirmationOpen={setConfirmationOpen} />
+          </Grid>
+        </Grid>
         )}
       </div>
       <div

--- a/src/shared/ProgressButtons.js
+++ b/src/shared/ProgressButtons.js
@@ -11,18 +11,6 @@ const ProgressButtons = ({ closeExpansionPanel, setConfirmationOpen }) => {
   const { state } = useContext(Context);
   const [isDisabled, setIsDisabled] = useState(false);
 
-  const renderProgressButtons = (progress, disabled) => {
-    if (progress < 0) return '';
-
-    return (
-      <ProgressButtonsInner
-        disabled={disabled}
-        closeExpansionPanel={closeExpansionPanel}
-        setConfirmationOpen={setConfirmationOpen}
-      />
-    );
-  };
-
   useEffect(() => {
     const section = window.location.href.includes('species-selector') ? 'selector' : 'explorer';
     const sfilters = state[section];
@@ -57,6 +45,18 @@ const ProgressButtons = ({ closeExpansionPanel, setConfirmationOpen }) => {
 
     disableLogic(state.progress, state.selectedGoals.length);
   }, [state]);
+
+  const renderProgressButtons = (progress, disabled) => {
+    if (progress < 0) return '';
+
+    return (
+      <ProgressButtonsInner
+        disabled={disabled}
+        closeExpansionPanel={closeExpansionPanel}
+        setConfirmationOpen={setConfirmationOpen}
+      />
+    );
+  };
 
   return renderProgressButtons(state.progress, isDisabled);
 };

--- a/src/shared/ProgressButtons.js
+++ b/src/shared/ProgressButtons.js
@@ -7,7 +7,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { Context } from '../store/Store';
 import ProgressButtonsInner from './ProgressButtonsInner';
 
-const ProgressButtons = () => {
+const ProgressButtons = ({ closeExpansionPanel, setConfirmationOpen }) => {
   const { state } = useContext(Context);
   const [isDisabled, setIsDisabled] = useState(false);
 
@@ -15,9 +15,11 @@ const ProgressButtons = () => {
     if (progress < 0) return '';
 
     return (
-      <div style={{ maxWidth: '150px', align: 'right' }}>
-        <ProgressButtonsInner disabled={disabled} />
-      </div>
+      <ProgressButtonsInner
+        disabled={disabled}
+        closeExpansionPanel={closeExpansionPanel}
+        setConfirmationOpen={setConfirmationOpen}
+      />
     );
   };
 

--- a/src/shared/ProgressButtonsInner.js
+++ b/src/shared/ProgressButtonsInner.js
@@ -44,12 +44,17 @@ const ProgressButtonsInner = ({ disabled, closeExpansionPanel, setConfirmationOp
   }, [state.progress]);
 
   return (
-    <Stack direction="row" ml={{ xs: '13%', sm: '30%', md: 1 }}>
+    <Stack
+      direction="row"
+      ml={{
+        xs: '13%', sm: '30%', md: '30%', lg: '10%',
+      }}
+    >
       <LightButton
         style={{
           maxWidth: '90px',
           maxHeight: '35px',
-          minWidth: '90px',
+          minWidth: '70px',
           fontSize: '13px',
           marginLeft: '3%',
         }}
@@ -61,7 +66,7 @@ const ProgressButtonsInner = ({ disabled, closeExpansionPanel, setConfirmationOp
         style={{
           maxWidth: '90px',
           maxHeight: '35px',
-          minWidth: '90px',
+          minWidth: '70px',
           fontSize: '13px',
           marginLeft: '3%',
         }}
@@ -84,12 +89,7 @@ const ProgressButtonsInner = ({ disabled, closeExpansionPanel, setConfirmationOp
         }}
       >
         <Refresh />
-        <p style={{
-          paddingBottom: '6px',
-        }}
-        >
-          &nbsp; Restart
-        </p>
+        Restart
       </LightButton>
     </Stack>
   );

--- a/src/shared/ProgressButtonsInner.js
+++ b/src/shared/ProgressButtonsInner.js
@@ -4,10 +4,12 @@
 */
 
 import React, { useState, useContext, useEffect } from 'react';
+import { Refresh } from '@mui/icons-material';
+import { Stack } from '@mui/material';
 import { Context } from '../store/Store';
 import { LightButton } from './constants';
 
-const ProgressButtonsInner = ({ disabled }) => {
+const ProgressButtonsInner = ({ disabled, closeExpansionPanel, setConfirmationOpen }) => {
   const isDisabled = disabled;
 
   const { state, dispatch } = useContext(Context);
@@ -41,17 +43,14 @@ const ProgressButtonsInner = ({ disabled }) => {
   }, [state.progress]);
 
   return (
-    <>
+    <Stack direction="row" ml={{ xs: '13%', sm: '30%', md: 1 }}>
       <LightButton
         style={{
-          maxWidth: '50px',
+          maxWidth: '90px',
           maxHeight: '35px',
-          minWidth: '50px',
-          minHeight: '35px',
-          fontSize: '11px',
-          marginLeft: '20px',
-          marginTop: '2.5px',
-          marginBottom: '2.5px',
+          minWidth: '90px',
+          fontSize: '13px',
+          marginLeft: '3%',
         }}
         onClick={() => changeProgress('decrement')}
       >
@@ -59,21 +58,39 @@ const ProgressButtonsInner = ({ disabled }) => {
       </LightButton>
       <LightButton
         style={{
-          maxWidth: '50px',
+          maxWidth: '90px',
           maxHeight: '35px',
-          minWidth: '50px',
-          minHeight: '35px',
-          fontSize: '11px',
-          marginTop: '2.5px',
-          marginBottom: '2.5px',
+          minWidth: '90px',
+          fontSize: '13px',
+          marginLeft: '3%',
         }}
         onClick={() => changeProgress('increment')}
         disabled={isDisabled || state.progress === 5}
-        className="ml-3"
       >
         NEXT
       </LightButton>
-    </>
+      <LightButton
+        style={{
+          maxWidth: '90px',
+          maxHeight: '35px',
+          minWidth: '90px',
+          fontSize: '13px',
+          marginLeft: '3%',
+        }}
+        onClick={() => {
+          closeExpansionPanel();
+          setConfirmationOpen(true);
+        }}
+      >
+        <Refresh />
+        <p style={{
+          paddingBottom: '6px',
+        }}
+        >
+          &nbsp; Restart
+        </p>
+      </LightButton>
+    </Stack>
   );
 };
 

--- a/src/shared/ProgressButtonsInner.js
+++ b/src/shared/ProgressButtonsInner.js
@@ -10,10 +10,11 @@ import { Context } from '../store/Store';
 import { LightButton } from './constants';
 
 const ProgressButtonsInner = ({ disabled, closeExpansionPanel, setConfirmationOpen }) => {
-  const isDisabled = disabled;
-
   const { state, dispatch } = useContext(Context);
+
   const [crement, setCrement] = useState('');
+
+  const isDisabled = disabled;
 
   const changeProgress = (type) => {
     setCrement(type);


### PR DESCRIPTION
Resolved issue [329 Fix info bar styling](https://github.com/precision-sustainable-ag/dst-selector/issues/329)
- Updated Info Bar styling to make it responsive for mobile view with the expected grid layout
- Added a tooltip for Info Bar elements like Location, Soil Drainage and First Frost so that users can view the values directly on hover
- Did some code refactoring to replace if else blocks with switch case or map array