### PR TITLE
Refactor/weather api calls

### DIFF
--- a/src/components/CropDetailsModal/CropDetailsModal.js
+++ b/src/components/CropDetailsModal/CropDetailsModal.js
@@ -12,7 +12,7 @@ import ReactGA from 'react-ga';
 import '../../styles/cropDetailsModal.scss';
 import InformationSheetContent from '../../pages/InformationSheetContent/InformationSheetContent';
 import { Context } from '../../store/Store';
-import { callSelectorApi } from '../../shared/constants';
+import { callCoverCropApi } from '../../shared/constants';
 
 const CropDetailsModal = ({ crop, setModalOpen, modalOpen }) => {
   const { state, dispatch } = useContext(Context);
@@ -22,7 +22,7 @@ const CropDetailsModal = ({ crop, setModalOpen, modalOpen }) => {
     const regionQuery = `${encodeURIComponent('regions')}=${encodeURIComponent(state.regionId)}`;
     const url = `https://${state.apiBaseURL}.covercrop-selector.org/v1/states/${state.stateId}/crops/${crop?.id}?${regionQuery}`;
     if (crop.id !== undefined) {
-      callSelectorApi(url).then((data) => {
+      callCoverCropApi(url).then((data) => {
         dispatch({
           type: 'MODAL_DATA',
           data,

--- a/src/pages/CoverCropExplorer/ExplorerCardView/ExplorerCardView.js
+++ b/src/pages/CoverCropExplorer/ExplorerCardView/ExplorerCardView.js
@@ -5,7 +5,7 @@
 */
 
 import {
-  Grid, Typography,
+  Grid, Typography, CircularProgress,
 } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import React, {
@@ -84,43 +84,47 @@ const ExplorerCardView = ({ activeCropData }) => {
   };
 
   return (
-    <>
-      <Grid style={{ marginLeft: '40px' }} container spacing={2}>
-        {/* eslint-disable-next-line no-nested-ternary */}
-        {activeCropData?.length > 0 ? (
-          activeCropData.map((crop, index) => (
-            <Grid style={{ width: '260px' }} item key={index}>
-              <CropCard
-                crop={crop}
-                handleModalOpen={handleModalOpen}
-                addCropToBasket={addCropToBasket}
-                selectedBtns={selectedBtns}
-                index={index}
-                removeCrop={addCropToBasket}
-                type="explorer"
-              />
+    state.ajaxInProgress ? (
+      <CircularProgress style={{ marginLeft: '60px' }} size="6em" />
+    ) : (
+      <>
+        <Grid style={{ marginLeft: '40px' }} container spacing={2}>
+          {/* eslint-disable-next-line no-nested-ternary */}
+          {activeCropData?.length > 0 ? (
+            activeCropData.map((crop, index) => (
+              <Grid style={{ width: '260px' }} item key={index}>
+                <CropCard
+                  crop={crop}
+                  handleModalOpen={handleModalOpen}
+                  addCropToBasket={addCropToBasket}
+                  selectedBtns={selectedBtns}
+                  index={index}
+                  removeCrop={addCropToBasket}
+                  type="explorer"
+                />
+              </Grid>
+            ))
+          ) : state?.cropData?.length > 0 ? (
+            <Grid item>
+              <Typography variant="body1" align="center">
+                No cover crops match your selected Cover Crop Property filters.
+              </Typography>
             </Grid>
-          ))
-        ) : state?.cropData?.length > 0 ? (
-          <Grid item>
-            <Typography variant="body1" align="center">
-              No cover crops match your selected Cover Crop Property filters.
-            </Typography>
-          </Grid>
-        ) : (
-          <div
-            style={{ padding: '50px 0 0 50px' }}
-          >
-            <b>Please select a zone</b>
-          </div>
-        )}
-      </Grid>
-      <CropDetailsModal
-        modalOpen={modalOpen}
-        setModalOpen={setModalOpen}
-        crop={modalData}
-      />
-    </>
+          ) : (
+            <div
+              style={{ padding: '50px 0 0 50px' }}
+            >
+              <b>Please select a zone</b>
+            </div>
+          )}
+        </Grid>
+        <CropDetailsModal
+          modalOpen={modalOpen}
+          setModalOpen={setModalOpen}
+          crop={modalData}
+        />
+      </>
+    )
   );
 };
 

--- a/src/pages/CropSidebar/CropSidebar.js
+++ b/src/pages/CropSidebar/CropSidebar.js
@@ -22,7 +22,7 @@ import React, {
   useContext, useEffect, useState,
 } from 'react';
 import { useDispatch } from 'react-redux';
-import { CustomStyles, callSelectorApi } from '../../shared/constants';
+import { CustomStyles, callCoverCropApi } from '../../shared/constants';
 import { Context, cropDataFormatter } from '../../store/Store';
 import '../../styles/cropSidebar.scss';
 import ComparisonBar from '../MyCoverCropList/ComparisonBar/ComparisonBar';
@@ -232,15 +232,20 @@ const CropSidebar = ({
 
   useEffect(() => {
     if (state.stateId && state.regionId) {
+      dispatch({
+        type: 'SET_AJAX_IN_PROGRESS',
+        data: true,
+      });
+
       setLoading(true);
-      callSelectorApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/states/${state.stateId}/dictionary?${query}`).then((data) => {
+      callCoverCropApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/states/${state.stateId}/dictionary?${query}`).then((data) => {
         dispatch({
           type: 'PULL_DICTIONARY_DATA',
           data: data.data,
         });
       });
 
-      callSelectorApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/states/${state.stateId}/filters?${query}`).then((data) => {
+      callCoverCropApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/states/${state.stateId}/filters?${query}`).then((data) => {
         const allFilters = [];
         data.data.forEach((category) => {
           allFilters.push(category.attributes);
@@ -249,11 +254,15 @@ const CropSidebar = ({
         setSidebarCategoriesData(data.data);
       });
 
-      callSelectorApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/states/${state.stateId}/crops?${query}`).then((data) => {
+      callCoverCropApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/states/${state.stateId}/crops?${query}`).then((data) => {
         cropDataFormatter(data.data);
         dispatch({
           type: 'PULL_CROP_DATA',
           data: data.data,
+        });
+        dispatch({
+          type: 'SET_AJAX_IN_PROGRESS',
+          data: false,
         });
       });
     }

--- a/src/pages/GoalsSelector/GoalsSelector.js
+++ b/src/pages/GoalsSelector/GoalsSelector.js
@@ -10,7 +10,7 @@ import MyCoverCropReset from '../../components/MyCoverCropReset/MyCoverCropReset
 import { Context } from '../../store/Store';
 import '../../styles/goalsSelector.scss';
 import GoalTag from './GoalTag/GoalTag';
-import { callSelectorApi } from '../../shared/constants';
+import { callCoverCropApi } from '../../shared/constants';
 
 // const goalSkeletonStyle = {
 //   height: '50px',
@@ -33,7 +33,7 @@ const GoalsSelector = () => {
 
   useEffect(() => {
     if (state.stateId && state.regionId) {
-      callSelectorApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/states/${state.stateId}/goals?${query}`).then((data) => {
+      callCoverCropApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/states/${state.stateId}/goals?${query}`).then((data) => {
         setAllGoals(data.data);
       });
     }

--- a/src/pages/Header/Header.js
+++ b/src/pages/Header/Header.js
@@ -5,19 +5,16 @@
 */
 
 import { useDispatch, useSelector } from 'react-redux';
-import Axios from 'axios';
-import moment from 'moment';
 import { useSnackbar } from 'notistack';
 import React, { useContext, useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
-import { abbrRegion, reverseGEO } from '../../shared/constants';
 import { Context } from '../../store/Store';
 import '../../styles/header.scss';
 import HeaderLogoInfo from './HeaderLogoInfo/HeaderLogoInfo';
 import InformationBar from './InformationBar/InformationBar';
 import ToggleOptions from './ToggleOptions/ToggleOptions';
 import {
-  lastZipCode, updateZipCode, updateZone,
+  lastZipCode, updateZone,
 } from '../../reduxStore/addressSlice';
 
 const Header = () => {
@@ -30,7 +27,6 @@ const Header = () => {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const isActive = {};
 
-  const weatherApiURL = 'https://weather.covercrop-data.org';
   const getUSDAZone = async (zip) => fetch(`https://phzmapi.org/${zip}.json`);
 
   useEffect(() => {
@@ -93,160 +89,6 @@ const Header = () => {
   }, [zipCodeRedux, lastZipCodeRedux, dispatch, dispatchRedux, enqueueSnackbar, closeSnackbar]);
 
   useEffect(() => {
-    // const { markers } = state;
-
-    // update address on marker change
-    // ref forecastComponent
-    const lat = markersRedux[0][0];
-    const lon = markersRedux[0][1];
-
-    // since this updates with state; ideally, weather and soil info should be updated here
-    // get current lat long and get county, state and city
-    if (state.progress >= 1 && markersRedux.length > 0) {
-      reverseGEO(lat, lon)
-        .then(async (resp) => {
-          const abbrState = abbrRegion(
-            resp?.features?.filter((feature) => feature?.place_type?.includes('region'))[0]?.text,
-            'abbr',
-          ).toLowerCase();
-
-          const city = resp?.features?.filter((feature) => feature?.place_type?.includes('place'))[0]?.text?.toLowerCase();
-          const zip = resp?.features?.filter((feature) => feature?.place_type?.includes('postcode'))[0]?.text;
-
-          if (zip) {
-            dispatchRedux(updateZipCode(zip));
-          }
-
-          const frostUrl = `${weatherApiURL}/frost?lat=${lat}&lon=${lon}`;
-          await Axios.get(frostUrl)
-            .then(((frostResp) => {
-              // added "/" and do %100 to get them into correct format (want frost dates to look like 01/01/23)
-              const currYear = `/${(new Date().getFullYear() % 100).toString()}`;
-              const prevYear = `/${((new Date().getFullYear() % 100) - 1).toString()}`;
-              const oneDay = 24 * 60 * 60 * 1000; // milliseconds in a day
-              const firstFrost = new Date(frostResp.data.firstfrost + prevYear);
-              const lastFrost = new Date(frostResp.data.lastfrost + currYear);
-
-              const frostFreeDaysObj = Math.round(Math.abs((firstFrost.valueOf() - lastFrost.valueOf()) / oneDay));
-              const averageFrostObject = {
-                firstFrostDate: {
-                  month: firstFrost.toLocaleString('en-US', { month: 'long' }),
-                  day: firstFrost.getDate().toString(),
-                },
-                lastFrostDate: {
-                  month: lastFrost.toLocaleString('en-US', { month: 'long' }),
-                  day: lastFrost.getDate().toString(),
-                },
-              };
-
-              return {
-                frostFreeDaysObj, city, abbrState, averageFrostObject,
-              };
-            }))
-            .then((obj) => {
-              dispatch({
-                type: 'UPDATE_FROST_FREE_DAYS',
-                data: { frostFreeDays: obj.frostFreeDaysObj },
-              });
-              dispatch({
-                type: 'UPDATE_AVERAGE_FROST_DATES',
-                data: {
-                  averageFrost: obj.averageFrostObject,
-                },
-              });
-              return obj;
-            })
-            .then(async (obj) => {
-              const currentMonthInt = moment().month() + 1;
-
-              // What was the 5-year average rainfall for city st during the month of currentMonthInt?
-              //  Dynamic dates ?
-              const averageRainUrl = `${weatherApiURL}/hourly?location=${obj.city}%20${obj.abbrState}&start=2015-01-01&end=2019-12-31`;
-              const averageRainForAMonthURL = `${averageRainUrl}&stats=sum(precipitation)/5&where=month=${currentMonthInt}&output=json`;
-              // What was the 5-year average annual rainfall for city st?
-              const fiveYearAvgRainURL = `${averageRainUrl}&stats=sum(precipitation)/5&output=json`;
-              if (!abbrState.ajaxInProgress) {
-                dispatch({
-                  type: 'SET_AJAX_IN_PROGRESS',
-                  data: true,
-                });
-                await Axios.get(averageRainForAMonthURL)
-                  .then((rainResp) => {
-                    let averagePrecipitationForCurrentMonth = rainResp.data[0]['sum(precipitation)/5'];
-                    averagePrecipitationForCurrentMonth = parseFloat(
-                      averagePrecipitationForCurrentMonth,
-                    ).toFixed(2);
-                    averagePrecipitationForCurrentMonth = parseFloat(
-                      averagePrecipitationForCurrentMonth * 0.03937,
-                    ).toFixed(2);
-                    dispatch({
-                      type: 'UPDATE_AVERAGE_PRECIP_CURRENT_MONTH',
-                      data: { thisMonth: averagePrecipitationForCurrentMonth },
-                    });
-                  })
-                  .catch((error) => {
-                    dispatch({
-                      type: 'SNACK',
-                      data: {
-                        snackOpen: true,
-                        snackMessage: `Weather API error code: ${error.response.status} for getting 5 year average rainfall for this month`,
-                      },
-                    });
-                  });
-
-                if (!abbrState.ajaxInProgress) {
-                  dispatch({
-                    type: 'SET_AJAX_IN_PROGRESS',
-                    data: true,
-                  });
-                  await Axios.get(fiveYearAvgRainURL)
-                    .then((rainResp) => {
-                      let fiveYearAvgRainAnnual = rainResp.data[0]['sum(precipitation)/5'];
-                      fiveYearAvgRainAnnual = parseFloat(fiveYearAvgRainAnnual).toFixed(2);
-                      fiveYearAvgRainAnnual = parseFloat(fiveYearAvgRainAnnual * 0.03937).toFixed(
-                        2,
-                      );
-                      dispatch({
-                        type: 'UPDATE_AVERAGE_PRECIP_ANNUAL',
-                        data: { annual: fiveYearAvgRainAnnual },
-                      });
-                      dispatch({
-                        type: 'SET_AJAX_IN_PROGRESS',
-                        data: false,
-                      });
-                    })
-                    .then(() => { })
-                    .catch((error) => {
-                      dispatch({
-                        type: 'SNACK',
-                        data: {
-                          snackOpen: true,
-                          snackMessage: `Weather API error code: ${error.response.status
-                          } for getting 5 year average rainfall for ${obj.city.toUpperCase()}, ${obj.state.toUpperCase()}`,
-                        },
-                      });
-                      dispatch({
-                        type: 'SET_AJAX_IN_PROGRESS',
-                        data: false,
-                      });
-                    });
-                }
-              }
-            })
-            .catch((err) => {
-              // eslint-disable-next-line no-console
-              console.error(`Failed to fetch frost data: ${err}`);
-            });
-        })
-        .then(() => {
-          dispatch({
-            type: 'SET_AJAX_IN_PROGRESS',
-            data: false,
-          });
-        });
-    }
-    // check if isRoot
-
     if (window.location.pathname === '/explorer') {
       setIsRoot(true);
     } else {
@@ -261,7 +103,7 @@ const Header = () => {
       default:
         break;
     }
-  }, [markersRedux, state.weatherDataReset]);
+  }, [markersRedux]);
 
   return (
     <header className="d-print-none">

--- a/src/pages/Help/InformationSheetDictionary/InformationSheetDictionary.js
+++ b/src/pages/Help/InformationSheetDictionary/InformationSheetDictionary.js
@@ -10,7 +10,7 @@ import React, {
 } from 'react';
 import { Context } from '../../../store/Store';
 import DictionaryContent from './DictionaryContent';
-import { callSelectorApi } from '../../../shared/constants';
+import { callCoverCropApi } from '../../../shared/constants';
 
 const InformationSheetDictionary = ({ zone, from }) => {
   const [dictionary, setDictionary] = useState([]);
@@ -23,7 +23,7 @@ const InformationSheetDictionary = ({ zone, from }) => {
   useEffect(() => {
     document.title = 'Data Dictionary';
     if (currentZone) {
-      callSelectorApi(`https://${state.apiBaseURL}.covercrop-selector.org/legacy/data-dictionary?zone=zone${currentZone}`)
+      callCoverCropApi(`https://${state.apiBaseURL}.covercrop-selector.org/legacy/data-dictionary?zone=zone${currentZone}`)
         .then((data) => { setDictionary(data); });
     }
   }, [zone]);

--- a/src/pages/InformationSheetContent/InformationSheetContent.js
+++ b/src/pages/InformationSheetContent/InformationSheetContent.js
@@ -15,7 +15,7 @@ import { ExpandMore } from '@mui/icons-material';
 import { Context } from '../../store/Store';
 import CoverCropInformation from './CoverCropInformation/CoverCropInformation';
 import InformationSheetReferences from './InformationSheetReferences/InformationSheetReferences';
-import { callSelectorApi, getRating } from '../../shared/constants';
+import { callCoverCropApi, getRating } from '../../shared/constants';
 
 const InformationSheetContent = ({ crop, modalData }) => {
   const { state } = useContext(Context);
@@ -29,9 +29,9 @@ const InformationSheetContent = ({ crop, modalData }) => {
   useEffect(() => {
     document.title = `${crop.label} Zone ${zone}`;
     if (state.stateId && state.regionId) {
-      callSelectorApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/crops/${crop?.id}/resources?${query}`)
+      callCoverCropApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/crops/${crop?.id}/resources?${query}`)
         .then((data) => setCurrentSources(data.data));
-      callSelectorApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/crops/${crop?.id}/images?${query}`)
+      callCoverCropApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/crops/${crop?.id}/images?${query}`)
         .then((data) => {
           setAllThumbs(data.data);
           setDataDone(true);

--- a/src/pages/Landing/Landing.js
+++ b/src/pages/Landing/Landing.js
@@ -23,7 +23,7 @@ import { useDispatch } from 'react-redux';
 import { Link, useHistory } from 'react-router-dom';
 import ReactGA from 'react-ga';
 import { RegionSelectorMap } from '@psa/dst.ui.region-selector-map';
-import { BinaryButton, callSelectorApi } from '../../shared/constants';
+import { BinaryButton, callCoverCropApi } from '../../shared/constants';
 import { Context } from '../../store/Store';
 import '../../styles/landing.scss';
 import ConsentModal from '../CoverCropExplorer/ConsentModal/ConsentModal';
@@ -72,7 +72,7 @@ const Landing = ({ height, title, bg }) => {
   };
 
   useEffect(() => {
-    callSelectorApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/states`).then((data) => { setAllStates(data.data); });
+    callCoverCropApi(`https://${state.apiBaseURL}.covercrop-selector.org/v1/states`).then((data) => { setAllStates(data.data); });
   }, []);
 
   useEffect(() => {

--- a/src/pages/Location/Location.js
+++ b/src/pages/Location/Location.js
@@ -18,13 +18,14 @@ import React, {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Search } from '@mui/icons-material';
-import Axios from 'axios';
 import moment from 'moment';
 import { Map } from '@psa/dst.ui.map';
 // import centroid from '@turf/centroid';
 import mapboxgl from 'mapbox-gl';
 import statesLatLongDict from '../../shared/stateslatlongdict';
-import { abbrRegion, reverseGEO, BinaryButton } from '../../shared/constants';
+import {
+  abbrRegion, reverseGEO, BinaryButton, callCoverCropApi,
+} from '../../shared/constants';
 import { Context } from '../../store/Store';
 import MyCoverCropReset from '../../components/MyCoverCropReset/MyCoverCropReset';
 import PlantHardinessZone from '../CropSidebar/PlantHardinessZone/PlantHardinessZone';
@@ -145,15 +146,9 @@ const LocationComponent = ({
       county,
     } = selectedToEditSite;
 
+    if (latitude === markersRedux[0][0] && longitude === markersRedux[0][1]) { return; }
+
     if (Object.keys(selectedToEditSite).length > 0) {
-      // dispatch({
-      //   type: 'UPDATE_LOCATION',
-      //   data: {
-      //     address,
-      //     markers: [[latitude, longitude]],
-      //     zipCode,
-      //   },
-      // });
       dispatchRedux(updateLocation(
         {
           address,
@@ -180,16 +175,6 @@ const LocationComponent = ({
             addressVerified: true,
           },
         ));
-        // dispatch({
-        //   type: 'CHANGE_ADDRESS_VIA_MAP',
-        //   data: {
-        //     address,
-        //     fullAddress,
-        //     zipCode,
-        //     county,
-        //     addressVerified: true,
-        //   },
-        // });
       }
       if (selectedZone) {
         handleMapChange();
@@ -223,16 +208,25 @@ const LocationComponent = ({
             dispatchRedux(updateZipCode(zip));
           }
 
+          const currentMonthInt = moment().month() + 1;
+          // frost url
           const frostUrl = `${weatherApiURL}/frost?lat=${lat}&lon=${lon}`;
-          await Axios.get(frostUrl)
-            .then(((frostResp) => {
-              // added "/" and do %100 to get them into correct format (want frost dates to look like 01/01/23)
-              const currYear = `/${(new Date().getFullYear() % 100).toString()}`;
-              const prevYear = `/${((new Date().getFullYear() % 100) - 1).toString()}`;
-              const oneDay = 24 * 60 * 60 * 1000; // milliseconds in a day
-              const firstFrost = new Date(frostResp.data.firstfrost + prevYear);
-              const lastFrost = new Date(frostResp.data.lastfrost + currYear);
+          // What was the 5-year average rainfall for city st during the month of currentMonthInt?
+          //  Dynamic dates ?
+          const averageRainUrl = `${weatherApiURL}/hourly?location=${city}%20${abbrState}&start=2015-01-01&end=2019-12-31`;
+          const averageRainForAMonthURL = `${averageRainUrl}&stats=sum(precipitation)/5&where=month=${currentMonthInt}&output=json`;
+          // What was the 5-year average annual rainfall for city st?
+          const fiveYearAvgRainURL = `${averageRainUrl}&stats=sum(precipitation)/5&output=json`;
+          // added "/" and do %100 to get them into correct format (want frost dates to look like 01/01/23)
+          const currYear = `/${(new Date().getFullYear() % 100).toString()}`;
+          const prevYear = `/${((new Date().getFullYear() % 100) - 1).toString()}`;
+          const oneDay = 24 * 60 * 60 * 1000; // milliseconds in a day
 
+          // call the frost url and then set frostFreeDays, averageFrostObject in store
+          callCoverCropApi(frostUrl)
+            .then(((frostResp) => {
+              const firstFrost = new Date(frostResp.firstfrost + prevYear);
+              const lastFrost = new Date(frostResp.lastfrost + currYear);
               const frostFreeDaysObj = Math.round(Math.abs((firstFrost.valueOf() - lastFrost.valueOf()) / oneDay));
               const averageFrostObject = {
                 firstFrostDate: {
@@ -245,110 +239,56 @@ const LocationComponent = ({
                 },
               };
 
-              return {
-                frostFreeDaysObj, city, abbrState, averageFrostObject,
-              };
-            }))
-            .then((obj) => {
               dispatch({
                 type: 'UPDATE_FROST_FREE_DAYS',
-                data: { frostFreeDays: obj.frostFreeDaysObj },
+                data: { frostFreeDays: frostFreeDaysObj },
               });
               dispatch({
                 type: 'UPDATE_AVERAGE_FROST_DATES',
                 data: {
-                  averageFrost: obj.averageFrostObject,
+                  averageFrost: averageFrostObject,
                 },
               });
-              return obj;
-            })
-            .then(async (obj) => {
-              const currentMonthInt = moment().month() + 1;
-
-              // What was the 5-year average rainfall for city st during the month of currentMonthInt?
-              //  Dynamic dates ?
-              const averageRainUrl = `${weatherApiURL}/hourly?location=${obj.city}%20${obj.abbrState}&start=2015-01-01&end=2019-12-31`;
-              const averageRainForAMonthURL = `${averageRainUrl}&stats=sum(precipitation)/5&where=month=${currentMonthInt}&output=json`;
-              // What was the 5-year average annual rainfall for city st?
-              const fiveYearAvgRainURL = `${averageRainUrl}&stats=sum(precipitation)/5&output=json`;
-              if (!abbrState.ajaxInProgress) {
-                dispatch({
-                  type: 'SET_AJAX_IN_PROGRESS',
-                  data: true,
-                });
-                await Axios.get(averageRainForAMonthURL)
-                  .then((rainResp) => {
-                    let averagePrecipitationForCurrentMonth = rainResp.data[0]['sum(precipitation)/5'];
-                    averagePrecipitationForCurrentMonth = parseFloat(
-                      averagePrecipitationForCurrentMonth,
-                    ).toFixed(2);
-                    averagePrecipitationForCurrentMonth = parseFloat(
-                      averagePrecipitationForCurrentMonth * 0.03937,
-                    ).toFixed(2);
-                    dispatch({
-                      type: 'UPDATE_AVERAGE_PRECIP_CURRENT_MONTH',
-                      data: { thisMonth: averagePrecipitationForCurrentMonth },
-                    });
-                  })
-                  .catch((error) => {
-                    dispatch({
-                      type: 'SNACK',
-                      data: {
-                        snackOpen: true,
-                        snackMessage: `Weather API error code: ${error.response.status} for getting 5 year average rainfall for this month`,
-                      },
-                    });
-                  });
-
-                if (!abbrState.ajaxInProgress) {
-                  dispatch({
-                    type: 'SET_AJAX_IN_PROGRESS',
-                    data: true,
-                  });
-                  await Axios.get(fiveYearAvgRainURL)
-                    .then((rainResp) => {
-                      let fiveYearAvgRainAnnual = rainResp.data[0]['sum(precipitation)/5'];
-                      fiveYearAvgRainAnnual = parseFloat(fiveYearAvgRainAnnual).toFixed(2);
-                      fiveYearAvgRainAnnual = parseFloat(fiveYearAvgRainAnnual * 0.03937).toFixed(
-                        2,
-                      );
-                      dispatch({
-                        type: 'UPDATE_AVERAGE_PRECIP_ANNUAL',
-                        data: { annual: fiveYearAvgRainAnnual },
-                      });
-                      dispatch({
-                        type: 'SET_AJAX_IN_PROGRESS',
-                        data: false,
-                      });
-                    })
-                    .then(() => { })
-                    .catch((error) => {
-                      dispatch({
-                        type: 'SNACK',
-                        data: {
-                          snackOpen: true,
-                          snackMessage: `Weather API error code: ${error.response.status
-                          } for getting 5 year average rainfall for ${obj.city.toUpperCase()}, ${obj.state.toUpperCase()}`,
-                        },
-                      });
-                      dispatch({
-                        type: 'SET_AJAX_IN_PROGRESS',
-                        data: false,
-                      });
-                    });
-                }
-              }
-            })
-            .catch((err) => {
-              // eslint-disable-next-line no-console
-              console.error(`Failed to fetch frost data: ${err}`);
+            })).catch((error) => {
+              // eslint-disable-next-line
+              console.log(`Weather API error code: ${error?.response?.status} for getting 5 year average rainfall for this month`);
             });
-        })
-        .then(() => {
-          dispatch({
-            type: 'SET_AJAX_IN_PROGRESS',
-            data: false,
-          });
+
+          // call the frost url and then set averagePrecipitationForCurrentMonth in store
+          callCoverCropApi(averageRainForAMonthURL)
+            .then((rainResp) => {
+              let averagePrecipitationForCurrentMonth = rainResp[0]['sum(precipitation)/5'];
+
+              averagePrecipitationForCurrentMonth = parseFloat(
+                averagePrecipitationForCurrentMonth * 0.03937,
+              ).toFixed(2);
+
+              dispatch({
+                type: 'UPDATE_AVERAGE_PRECIP_CURRENT_MONTH',
+                data: { thisMonth: averagePrecipitationForCurrentMonth },
+              });
+            })
+            .catch((error) => {
+              // eslint-disable-next-line
+              console.log(`Weather API error code: ${error?.response?.status} for getting 5 year average rainfall for this month`);
+            });
+
+          // call the frost url and then set fiveYearAvgRainAnnual in store
+          callCoverCropApi(fiveYearAvgRainURL)
+            .then((rainResp) => {
+              let fiveYearAvgRainAnnual = rainResp[0]['sum(precipitation)/5'];
+              fiveYearAvgRainAnnual = parseFloat(fiveYearAvgRainAnnual * 0.03937).toFixed(
+                2,
+              );
+              dispatch({
+                type: 'UPDATE_AVERAGE_PRECIP_ANNUAL',
+                data: { annual: fiveYearAvgRainAnnual },
+              });
+            })
+            .catch((error) => {
+              // eslint-disable-next-line
+              console.log(`Weather API error code: ${error?.response?.status} for getting 5 year average rainfall for this month`);
+            });
         });
     }
   }, [markersRedux]);

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -683,7 +683,7 @@ export const reverseGEO = async (lat, lng) => {
   return data;
 };
 
-export const callSelectorApi = async (url) => fetch(url)
+export const callCoverCropApi = async (url) => fetch(url)
   .then((res) => res.json())
   .catch((err) => {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
- remove redundant api calls on marker change
- make weather api calls in parallel
- add spinner to explorer view for api call duration
- fix calendar view showing spinner for ages, the issue was that it waited for crop call, and 4 weather api calls to be made in serial twice which takes ages. now it only spins for the duration of one /crops api call
- reduced logic for weather api calls by about 100 lines
- moved weather api call into Location.js from Header.js