### PR TITLE
Not show consent and login modal after selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "mdbreact": "^4.24.0",
         "moment": "^2.24.0",
         "moment-timezone": "^0.5.28",
-        "notistack": "^2.0.5",
+        "notistack": "^2.0.8",
         "prop-types": "^15.7.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "mdbreact": "^4.24.0",
         "moment": "^2.24.0",
         "moment-timezone": "^0.5.28",
-        "notistack": "^2.0.8",
+        "notistack": "^2.0.5",
         "prop-types": "^15.7.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/components/CropDetailsModal/CropDetailsModal.js
+++ b/src/components/CropDetailsModal/CropDetailsModal.js
@@ -18,7 +18,7 @@ const CropDetailsModal = ({ crop, setModalOpen, modalOpen }) => {
   // redux vars
   const regionIdRedux = useSelector((stateRedux) => stateRedux.mapData.regionId);
   const stateIdRedux = useSelector((stateRedux) => stateRedux.mapData.stateId);
-  const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
+  const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
   const apiBaseUrlRedux = useSelector((stateRedux) => stateRedux.sharedData.apiBaseUrl);
 
   // useState vars

--- a/src/pages/About/About.js
+++ b/src/pages/About/About.js
@@ -17,7 +17,7 @@ import MITLicenseText from '../License/MITLicenseText/MITLicenseText';
 
 const About = () => {
   const [value, setValue] = React.useState(0);
-  const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
+  const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
 
   const handleChange = (newValue) => {
     setValue(newValue);

--- a/src/pages/CoverCropExplorer/ConsentModal/ConsentModal.js
+++ b/src/pages/CoverCropExplorer/ConsentModal/ConsentModal.js
@@ -3,12 +3,12 @@ import {
 } from '@mui/material';
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { updateConsent } from '../../../reduxStore/sharedSlice';
+import { updateConsent } from '../../../reduxStore/userSlice';
 
 const ConsentModal = () => {
   const [modalOpen, setModalOpen] = useState(true);
   const dispatchRedux = useDispatch();
-  const hideConsentRedux = useSelector((stateRedux) => stateRedux.sharedData.hideConsentModal);
+  const hideConsentRedux = useSelector((stateRedux) => stateRedux.userData.hideConsentModal);
 
   const style = {
     position: 'absolute',

--- a/src/pages/CoverCropExplorer/ConsentModal/ConsentModal.js
+++ b/src/pages/CoverCropExplorer/ConsentModal/ConsentModal.js
@@ -2,12 +2,13 @@ import {
   Modal, Box, Typography, Button, Grid,
 } from '@mui/material';
 import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { updateConsent } from '../../../reduxStore/sharedSlice';
 
-const ConsentModual = ({ consent }) => {
+const ConsentModal = () => {
   const [modalOpen, setModalOpen] = useState(true);
   const dispatchRedux = useDispatch();
+  const hideConsentRedux = useSelector((stateRedux) => stateRedux.sharedData.hideConsentModal);
 
   const style = {
     position: 'absolute',
@@ -26,7 +27,7 @@ const ConsentModual = ({ consent }) => {
     dispatchRedux(updateConsent(choice));
   };
 
-  return !consent && !/crop=/.test(window.location.search) && (
+  return !hideConsentRedux && !/crop=/.test(window.location.search) && (
     <Modal
       open={modalOpen}
       //   onClose={toggleModalOpen}
@@ -73,4 +74,4 @@ const ConsentModual = ({ consent }) => {
   );
 };
 
-export default ConsentModual;
+export default ConsentModal;

--- a/src/pages/CoverCropExplorer/CoverCropExplorer.js
+++ b/src/pages/CoverCropExplorer/CoverCropExplorer.js
@@ -27,7 +27,7 @@ const CoverCropExplorer = () => {
   const activeCropDataRedux = useSelector((stateRedux) => stateRedux.cropData.activeCropData);
   const cropDataRedux = useSelector((stateRedux) => stateRedux.cropData.cropData);
   const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
-  const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
+  const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
   const myCoverCropListLocationRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropListLocation);
   const [updatedActiveCropData, setUpdatedActiveCropData] = useState([]);
   // const { activeCropData } = state;

--- a/src/pages/CoverCropExplorer/CoverCropExplorer.js
+++ b/src/pages/CoverCropExplorer/CoverCropExplorer.js
@@ -92,7 +92,7 @@ const CoverCropExplorer = () => {
 
   return (
     <div className="contentWrapper">
-      <ConsentModal consent={consentRedux} />
+      <ConsentModal />
       <Header logo="neccc_wide_logo_color_web.jpg" />
       <div className="container-fluid mt-4 mb-4">
         <div className="row mt-3">

--- a/src/pages/CropSelector/CropSelector.js
+++ b/src/pages/CropSelector/CropSelector.js
@@ -62,7 +62,7 @@ const CropSelector = (props) => {
   const cropDataRedux = useSelector((stateRedux) => stateRedux.cropData.cropData);
   const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
   const selectedGoalsRedux = useSelector((stateRedux) => stateRedux.goalsData.selectedGoals);
-  const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
+  const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
   const speciesSelectorActivationFlagRedux = useSelector((stateRedux) => stateRedux.sharedData.speciesSelectorActivationFlag);
   const myCoverCropListLocationRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropListLocation);
 

--- a/src/pages/Feedback/Feedback.js
+++ b/src/pages/Feedback/Feedback.js
@@ -14,7 +14,7 @@ import {
 import Header from '../Header/Header';
 
 const FeedbackComponent = () => {
-  const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
+  const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
   const [snackbarData, setSnackbarData] = useState({ open: false, message: '', color: '' });
   const [feedbackData, setFeedbackData] = useState({
     repository: 'dst-feedback',

--- a/src/pages/Header/Header.js
+++ b/src/pages/Header/Header.js
@@ -20,7 +20,7 @@ const Header = () => {
   const dispatchRedux = useDispatch();
   const markersRedux = useSelector((stateRedux) => stateRedux.addressData.markers);
   const progressRedux = useSelector((stateRedux) => stateRedux.sharedData.progress);
-  const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
+  const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
   const [isRoot, setIsRoot] = useState(false);
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
   const isActive = {};

--- a/src/pages/Help/Help.js
+++ b/src/pages/Help/Help.js
@@ -19,7 +19,7 @@ import Header from '../Header/Header';
 import InformationSheetDictionary from './InformationSheetDictionary/InformationSheetDictionary';
 
 const Help = () => {
-  const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
+  const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
 
   useEffect(() => {
     document.title = 'Help Page';

--- a/src/pages/Landing/Landing.js
+++ b/src/pages/Landing/Landing.js
@@ -218,7 +218,7 @@ const Landing = ({ height, title, bg }) => {
         backgroundSize: 'cover',
       }}
     >
-      { (!hideConsentRedux && (!authModalOpen || isAuthenticated)) && <ConsentModal consent={consentRedux} />}
+      { (!authModalOpen || isAuthenticated) && <ConsentModal />}
       { (!hideConsentRedux && !isAuthenticated) && <AuthModal modalOpen={authModalOpen} setModalOpen={setAuthModalOpen} />}
 
       <Grid container>

--- a/src/pages/Landing/Landing.js
+++ b/src/pages/Landing/Landing.js
@@ -218,8 +218,8 @@ const Landing = ({ height, title, bg }) => {
         backgroundSize: 'cover',
       }}
     >
-      { (!authModalOpen || isAuthenticated) && <ConsentModal />}
-      { (!hideConsentRedux && !isAuthenticated) && <AuthModal modalOpen={authModalOpen} setModalOpen={setAuthModalOpen} />}
+      {(!authModalOpen || isAuthenticated) && <ConsentModal />}
+      {(!hideConsentRedux && !isAuthenticated) && <AuthModal modalOpen={authModalOpen} setModalOpen={setAuthModalOpen} />}
 
       <Grid container>
 

--- a/src/pages/Landing/Landing.js
+++ b/src/pages/Landing/Landing.js
@@ -42,6 +42,7 @@ const Landing = ({ height, title, bg }) => {
   const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
   const myCoverCropListLocationRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropListLocation);
   const apiBaseUrlRedux = useSelector((stateRedux) => stateRedux.sharedData.apiBaseUrl);
+  const hideConsentRedux = useSelector((stateRedux) => stateRedux.sharedData.hideConsentModal);
 
   // useState vars
   const [handleConfirm, setHandleConfirm] = useState(false);
@@ -217,8 +218,8 @@ const Landing = ({ height, title, bg }) => {
         backgroundSize: 'cover',
       }}
     >
-      {(!authModalOpen || isAuthenticated) && <ConsentModal consent={consentRedux} />}
-      {!isAuthenticated && <AuthModal modalOpen={authModalOpen} setModalOpen={setAuthModalOpen} />}
+      { (!hideConsentRedux && (!authModalOpen || isAuthenticated)) && <ConsentModal consent={consentRedux} />}
+      { (!hideConsentRedux && !isAuthenticated) && <AuthModal modalOpen={authModalOpen} setModalOpen={setAuthModalOpen} />}
 
       <Grid container>
 

--- a/src/pages/Landing/Landing.js
+++ b/src/pages/Landing/Landing.js
@@ -39,10 +39,10 @@ const Landing = ({ height, title, bg }) => {
   const stateIdRedux = useSelector((stateRedux) => stateRedux.mapData.stateId);
   const councilLabelRedux = useSelector((stateRedux) => stateRedux.mapData.councilLabel);
   const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
-  const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
+  const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
   const myCoverCropListLocationRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropListLocation);
   const apiBaseUrlRedux = useSelector((stateRedux) => stateRedux.sharedData.apiBaseUrl);
-  const hideConsentRedux = useSelector((stateRedux) => stateRedux.sharedData.hideConsentModal);
+  const hideConsentRedux = useSelector((stateRedux) => stateRedux.userData.hideConsentModal);
 
   // useState vars
   const [handleConfirm, setHandleConfirm] = useState(false);

--- a/src/pages/MyCoverCropList/MyCoverCropList.js
+++ b/src/pages/MyCoverCropList/MyCoverCropList.js
@@ -22,7 +22,7 @@ const MyCoverCropList = ({ comparisonView, from }) => {
   const [updatedSelectedCrops, setUpdatedSelectedCrops] = useState([]);
   const stateLabelRedux = useSelector((stateRedux) => stateRedux.mapData.stateLabel);
   const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
-  const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
+  const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
   // const { selectedCrops } = state;
 
   useEffect(() => {

--- a/src/reduxStore/sharedSlice.js
+++ b/src/reduxStore/sharedSlice.js
@@ -1,6 +1,7 @@
 const initialState = {
   progress: 0,
   consent: false,
+  hideConsentModal: false,
   snackOpen: false,
   snackMessage: '',
   ajaxInProgress: false,
@@ -113,12 +114,12 @@ const sharedReducer = (state = initialState, action = null) => {
 
     case 'UPDATE_CONSENT':
       if (action.payload.value === true) {
-        return { ...state, consent: true };
+        return { ...state, consent: true, hideConsentModal: true };
       }
       if (action.payload.value === false) {
-        return { ...state, consent: false };
+        return { ...state, consent: false, hideConsentModal: true };
       }
-      return { ...state };
+      return { ...state, hideConsentModal: true };
 
     case 'GOTO_PROGRESS':
       return {

--- a/src/reduxStore/sharedSlice.js
+++ b/src/reduxStore/sharedSlice.js
@@ -1,7 +1,5 @@
 const initialState = {
   progress: 0,
-  consent: false,
-  hideConsentModal: false,
   snackOpen: false,
   snackMessage: '',
   ajaxInProgress: false,
@@ -20,13 +18,6 @@ const initialState = {
 
 export const updateProgress = (value) => ({
   type: 'UPDATE_PROGRESS',
-  payload: {
-    value,
-  },
-});
-
-export const updateConsent = (value) => ({
-  type: 'UPDATE_CONSENT',
   payload: {
     value,
   },
@@ -111,15 +102,6 @@ const sharedReducer = (state = initialState, action = null) => {
         return { ...state, progress: 0 };
       }
       return { ...state };
-
-    case 'UPDATE_CONSENT':
-      if (action.payload.value === true) {
-        return { ...state, consent: true, hideConsentModal: true };
-      }
-      if (action.payload.value === false) {
-        return { ...state, consent: false, hideConsentModal: true };
-      }
-      return { ...state, hideConsentModal: true };
 
     case 'GOTO_PROGRESS':
       return {

--- a/src/reduxStore/store.js
+++ b/src/reduxStore/store.js
@@ -29,7 +29,19 @@ const configureStore = () => {
 
   const rootReducer = (state, action) => {
     if (action.type === 'RESET') {
-      return appReducer(undefined, action);
+      return {
+        ...state,
+        cropData: cropDataReducer(undefined, action),
+        mapData: MapReducer(undefined, action),
+        weatherData: weatherReducer(undefined, action),
+        goalsData: goalsReducer(undefined, action),
+        sharedData: sharedReducer(undefined, action),
+        soilData: soilReducer(undefined, action),
+        filterData: filterReducer(undefined, action),
+        addressData: addressReducer(undefined, action),
+        // keep the userData as the same
+        userData: state.userData,
+      };
     }
 
     return appReducer(state, action);

--- a/src/reduxStore/userSlice.js
+++ b/src/reduxStore/userSlice.js
@@ -1,6 +1,8 @@
 const initialState = {
   accessToken: null,
   field: null,
+  consent: false,
+  hideConsentModal: false,
 };
 
 export const updateAccessToken = (token) => ({
@@ -13,12 +15,19 @@ export const updateField = (field) => ({
   payload: { field },
 });
 
+export const updateConsent = (consent) => ({
+  type: 'UPDATE_CONSENT',
+  payload: { consent },
+});
+
 const userReducer = (state = initialState, action = null) => {
   switch (action.type) {
     case 'UPDATE_ACCESSTOKEN':
       return { ...state, accessToken: action.payload.token };
     case 'UPDATE_FIELD':
       return { ...state, field: action.payload.field };
+    case 'UPDATE_CONSENT':
+      return { ...state, consent: action.payload.consent, hideConsentModal: true };
     default:
       return { ...state };
   }


### PR DESCRIPTION
- Hide the consent modal and login modal after user make a selection.
- There is a situations which will reshow the modal, after the user logged in and then click the logout button on right top, it will redirect the page to Auth0 logout site, and when come back all the redux states will be refreshed. 
- Moved the consent redux state to userSlice, also not reset userSlice when there is a reset action.