### PR TITLE
Refractor index and app structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "mdbreact": "^4.24.0",
         "moment": "^2.24.0",
         "moment-timezone": "^0.5.28",
-        "notistack": "^2.0.5",
         "prop-types": "^15.7.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@
 */
 
 import {
-  Snackbar, Box, Container, Grid, Typography,
+  Snackbar, Box, Container, Grid,
 } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -16,9 +16,54 @@ import LocationComponent from './pages/Location/Location';
 import LocationConfirmation from './pages/Location/LocationConfirmation/LocationConfirmation';
 import './styles/App.scss';
 import { snackHandler } from './reduxStore/sharedSlice';
+import RouteNotFound from './pages/RouteNotFound/RouteNotFound';
+
+const App = () => {
+  const [calcHeight, setCalcHeight] = useState(0);
+
+  const progressRedux = useSelector((stateRedux) => stateRedux.sharedData.progress);
+
+  useEffect(() => {
+    const parentDocHeight = document
+      .getElementById('mainContentWrapper')
+      .getBoundingClientRect().height;
+    const headerHeight = document.querySelector('header').getBoundingClientRect().height;
+
+    const calculatedHeight = parentDocHeight - headerHeight;
+
+    setCalcHeight(calculatedHeight);
+  }, []);
+
+  return (
+    <Box className="contentWrapper" id="mainContentWrapper">
+      <Header logo="neccc_wide_logo_color_web.jpg" />
+
+      <Container disableGutters maxWidth={false}>
+        <Box className="contentContainer">
+
+          <Grid container item xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
+            <LoadRelevantRoute progress={progressRedux} calcHeight={calcHeight} />
+          </Grid>
+
+        </Box>
+      </Container>
+
+    </Box>
+  );
+};
+
+export default App;
 
 const LoadRelevantRoute = ({ progress, calcHeight }) => {
   switch (progress) {
+    case 0:
+      return (
+        <Landing
+          title="Decision Support Tool"
+          height={calcHeight}
+          bg="/images/cover-crop-field.png"
+        />
+      );
     case 1:
       return (
         <LocationComponent
@@ -54,14 +99,13 @@ const LoadRelevantRoute = ({ progress, calcHeight }) => {
   }
 };
 
-const App = () => {
+// eslint-disable-next-line no-unused-vars
+const SnackbarComponent = () => {
   const dispatchRedux = useDispatch();
-  const [calcHeight, setCalcHeight] = useState(0);
 
   // redux vars
   const snackOpenRedux = useSelector((stateRedux) => stateRedux.sharedData.snackOpen);
   const snackMessageRedux = useSelector((stateRedux) => stateRedux.sharedData.snackMessage);
-  const progressRedux = useSelector((stateRedux) => stateRedux.sharedData.progress);
   const snackVerticalRedux = useSelector((stateRedux) => stateRedux.sharedData.snackVertical);
   const snackHorizontalRedux = useSelector((stateRedux) => stateRedux.sharedData.snackHorizontal);
 
@@ -69,70 +113,25 @@ const App = () => {
     dispatchRedux(snackHandler({ snackOpen: false, snackMessage: '' }));
   };
 
-  useEffect(() => {
-    const parentDocHeight = document
-      .getElementById('mainContentWrapper')
-      .getBoundingClientRect().height;
-    const headerHeight = document.querySelector('header').getBoundingClientRect().height;
-
-    const calculatedHeight = parentDocHeight - headerHeight;
-
-    setCalcHeight(calculatedHeight);
-  }, []);
-
   return (
-    <Box className="contentWrapper" id="mainContentWrapper">
-      <Header logo="neccc_wide_logo_color_web.jpg" />
-
-      <Container disableGutters maxWidth={false}>
-        <Box className="contentContainer">
-          {progressRedux === 0 ? (
-            <Landing
-              title="Decision Support Tool"
-              height={calcHeight}
-              bg="/images/cover-crop-field.png"
-            />
-          ) : (
-            <Grid container item xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
-              <LoadRelevantRoute progress={progressRedux} calcHeight={calcHeight} />
-            </Grid>
-          )}
-        </Box>
-      </Container>
-
-      <div>
-        <Snackbar
-          anchorOrigin={{
-            vertical: snackVerticalRedux,
-            horizontal: snackHorizontalRedux,
-          }}
-          key={{
-            vertical: snackVerticalRedux,
-            horizontal: snackHorizontalRedux,
-          }}
-          autoHideDuration={3000}
-          open={snackOpenRedux}
-          onClose={handleSnackClose}
-          ContentProps={{
-            'aria-describedby': 'message-id',
-          }}
-          message={snackMessageRedux}
-        />
-      </div>
-    </Box>
+    <div>
+      <Snackbar
+        anchorOrigin={{
+          vertical: snackVerticalRedux,
+          horizontal: snackHorizontalRedux,
+        }}
+        key={{
+          vertical: snackVerticalRedux,
+          horizontal: snackHorizontalRedux,
+        }}
+        autoHideDuration={3000}
+        open={snackOpenRedux}
+        onClose={handleSnackClose}
+        ContentProps={{
+          'aria-describedby': 'message-id',
+        }}
+        message={snackMessageRedux}
+      />
+    </div>
   );
 };
-
-export default App;
-
-const RouteNotFound = () => (
-  <Container>
-    <Grid container justifyContent="center" alignItems="center" spacing={3}>
-      <Grid item xs={4}>
-        <Typography variant="h3" align="center">
-          Unknown Route
-        </Typography>
-      </Grid>
-    </Grid>
-  </Container>
-);

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,6 @@ import {
 import { createTheme } from '@mui/material/styles';
 import React, { useEffect, useState, Suspense } from 'react';
 import { useDispatch, useSelector, Provider } from 'react-redux';
-import { SnackbarProvider } from 'notistack';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
 
 import configureStore from './reduxStore/store';
@@ -109,60 +108,52 @@ const csTheme = responsiveFontSizes(theme, {
 const App = () => (
   <StyledEngineProvider injectFirst>
     <ThemeProvider theme={csTheme}>
-      <SnackbarProvider
-        maxSnack={5}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
-        autoHideDuration={15000}
-      >
-        <Provider store={store}>
-          <BrowserRouter>
-            <Auth0ProviderWithHistory>
-              <Suspense fallback={<div>Loading..</div>}>
-                <Box className="contentWrapper" id="mainContentWrapper">
-                  <Header />
-                  <Container disableGutters maxWidth={false}>
-                    <Box className="contentContainer">
+      <Provider store={store}>
+        <BrowserRouter>
+          <Auth0ProviderWithHistory>
+            <Suspense fallback={<div>Loading..</div>}>
+              <Box className="contentWrapper" id="mainContentWrapper">
+                <Header />
+                <Container disableGutters maxWidth={false}>
+                  <Box className="contentContainer">
 
-                      <Switch>
-                        <Route
-                          path="/"
-                          render={() => (
-                            <Grid container item xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
-                              <LoadRelevantRoute />
-                            </Grid>
-                          )}
-                          exact
-                        />
-                        <Route path="/explorer" component={CoverCropExplorer} exact />
-                        <Route path="/about" component={About} exact />
-                        <Route path="/help" component={Help} exact />
-                        <Route path="/feedback" component={FeedbackComponent} exact />
-                        <Route path="/profile" component={Profile} exact />
-                        <Route path="/my-cover-crop-list" component={MyCoverCropListWrapper} exact />
-                        <Route path="/seeding-rate-calculator" component={SeedingRateCalculator} exact />
-                        <Route path="/data-dictionary" component={InformationSheetDictionary} exact />
-                        <Route path="/license" render={() => <License licenseType="MIT" />} exact />
-                        <Route
-                          path="/ag-informatics-license"
-                          render={() => <License licenseType="AgInformatics" />}
-                          exact
-                        />
-                        <Route path="/mix-maker" component={MixMaker} exact />
+                    <Switch>
+                      <Route
+                        path="/"
+                        render={() => (
+                          <Grid container item xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
+                            <LoadRelevantRoute />
+                          </Grid>
+                        )}
+                        exact
+                      />
+                      <Route path="/explorer" component={CoverCropExplorer} exact />
+                      <Route path="/about" component={About} exact />
+                      <Route path="/help" component={Help} exact />
+                      <Route path="/feedback" component={FeedbackComponent} exact />
+                      <Route path="/profile" component={Profile} exact />
+                      <Route path="/my-cover-crop-list" component={MyCoverCropListWrapper} exact />
+                      <Route path="/seeding-rate-calculator" component={SeedingRateCalculator} exact />
+                      <Route path="/data-dictionary" component={InformationSheetDictionary} exact />
+                      <Route path="/license" render={() => <License licenseType="MIT" />} exact />
+                      <Route
+                        path="/ag-informatics-license"
+                        render={() => <License licenseType="AgInformatics" />}
+                        exact
+                      />
+                      <Route path="/mix-maker" component={MixMaker} exact />
 
-                        <Route component={RouteNotFound} />
-                      </Switch>
-                    </Box>
-                  </Container>
-                </Box>
-                <Footer />
-              </Suspense>
-            </Auth0ProviderWithHistory>
-          </BrowserRouter>
-        </Provider>
-      </SnackbarProvider>
+                      <Route component={RouteNotFound} />
+                    </Switch>
+                  </Box>
+                </Container>
+              </Box>
+              <SnackbarComponent />
+              <Footer />
+            </Suspense>
+          </Auth0ProviderWithHistory>
+        </BrowserRouter>
+      </Provider>
     </ThemeProvider>
   </StyledEngineProvider>
 
@@ -245,24 +236,19 @@ const SnackbarComponent = () => {
   };
 
   return (
-    <div>
-      <Snackbar
-        anchorOrigin={{
-          vertical: snackVerticalRedux,
-          horizontal: snackHorizontalRedux,
-        }}
-        key={{
-          vertical: snackVerticalRedux,
-          horizontal: snackHorizontalRedux,
-        }}
-        autoHideDuration={3000}
-        open={snackOpenRedux}
-        onClose={handleSnackClose}
-        ContentProps={{
-          'aria-describedby': 'message-id',
-        }}
-        message={snackMessageRedux}
-      />
-    </div>
+    <Snackbar
+      anchorOrigin={{
+        vertical: snackVerticalRedux,
+        horizontal: snackHorizontalRedux,
+      }}
+      key={snackOpenRedux + snackMessageRedux}
+      autoHideDuration={3000}
+      open={snackOpenRedux}
+      onClose={handleSnackClose}
+      ContentProps={{
+        'aria-describedby': 'message-id',
+      }}
+      message={snackMessageRedux}
+    />
   );
 };

--- a/src/App.js
+++ b/src/App.js
@@ -4,21 +4,173 @@
 */
 
 import {
-  Snackbar, Box, Container, Grid,
+  Snackbar, Box, Container, Grid, ThemeProvider,
+  StyledEngineProvider,
+  responsiveFontSizes,
+  adaptV4Theme,
 } from '@mui/material';
-import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { createTheme } from '@mui/material/styles';
+import React, { useEffect, useState, Suspense } from 'react';
+import { useDispatch, useSelector, Provider } from 'react-redux';
+import { SnackbarProvider } from 'notistack';
+import { BrowserRouter, Switch, Route } from 'react-router-dom';
+
+import configureStore from './reduxStore/store';
+import { CustomStyles } from './shared/constants';
+
 import CropSelector from './pages/CropSelector/CropSelector';
 import GoalsSelector from './pages/GoalsSelector/GoalsSelector';
 import Header from './pages/Header/Header';
 import Landing from './pages/Landing/Landing';
 import LocationComponent from './pages/Location/Location';
 import LocationConfirmation from './pages/Location/LocationConfirmation/LocationConfirmation';
-import './styles/App.scss';
 import { snackHandler } from './reduxStore/sharedSlice';
 import RouteNotFound from './pages/RouteNotFound/RouteNotFound';
+import Auth0ProviderWithHistory from './components/Auth/Auth0ProviderWithHistory/Auth0ProviderWithHistory';
+import Footer from './pages/Footer/Footer';
+import About from './pages/About/About';
+import SeedingRateCalculator from './pages/SeedingRateCalculator/SeedingRateCalculator';
+import MixMaker from './pages/MixMaker/MixMaker';
+import CoverCropExplorer from './pages/CoverCropExplorer/CoverCropExplorer';
+import FeedbackComponent from './pages/Feedback/Feedback';
+import InformationSheetDictionary from './pages/Help/InformationSheetDictionary/InformationSheetDictionary';
+import License from './pages/License/License';
+import MyCoverCropListWrapper from './pages/MyCoverCropList/MyCoverCropListWrapper/MyCoverCropListWrapper';
+import Help from './pages/Help/Help';
+import Profile from './pages/Profile/Profile';
 
-const App = () => {
+import './styles/App.scss';
+import './styles/parent.scss';
+import 'mdbreact/dist/css/mdb.css';
+import './styles/progressBar.css';
+
+const store = configureStore();
+
+// AdaptV4Theme has been depreciated and v5 is the new version.  TODO: look into update
+const theme = createTheme(
+  adaptV4Theme({
+    palette: {
+      primary: {
+        main: CustomStyles().lightGreen,
+      },
+      secondary: {
+        main: CustomStyles().lighterGreen,
+      },
+    },
+    overrides: {
+      MuiTooltip: {
+        tooltip: {
+          fontWeight: 'normal',
+          fontSize: CustomStyles().defaultFontSize,
+          backgroundColor: CustomStyles().secondaryProgressBtnColor,
+          color: 'black',
+          borderRadius: CustomStyles().mildlyRoundedRadius,
+        },
+        arrow: {},
+      },
+      MuiChip: {
+        root: {
+          '&&:hover': {
+            boxShadow: '0 0 3px 0 black',
+          },
+          border: '1px solid #777',
+        },
+        colorSecondary: {
+          '&, &&:hover, &&:focus': {
+            backgroundColor: CustomStyles().greenishWhite,
+            color: 'rgba(0,0,0,0.9)',
+            fontWeight: 'normal',
+          },
+        },
+        colorPrimary: {
+          '&, &&:hover, &&:focus': {
+            backgroundColor: CustomStyles().darkGreen,
+            color: 'white',
+            fontWeight: 'normal',
+          },
+        },
+        sizeSmall: {
+          fontSize: '1.2rem',
+        },
+      },
+      MuiDialog: {
+        root: {
+          zIndex: 1000003,
+        },
+      },
+    },
+  }),
+);
+
+const csTheme = responsiveFontSizes(theme, {
+  breakpoints: ['xs', 'sm', 'md', 'lg', 'xl'],
+});
+
+const App = () => (
+  <StyledEngineProvider injectFirst>
+    <ThemeProvider theme={csTheme}>
+      <SnackbarProvider
+        maxSnack={5}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        autoHideDuration={15000}
+      >
+        <Provider store={store}>
+          <BrowserRouter>
+            <Auth0ProviderWithHistory>
+              <Suspense fallback={<div>Loading..</div>}>
+                <Box className="contentWrapper" id="mainContentWrapper">
+                  <Header />
+                  <Container disableGutters maxWidth={false}>
+                    <Box className="contentContainer">
+
+                      <Switch>
+                        <Route
+                          path="/"
+                          render={() => (
+                            <Grid container item xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
+                              <LoadRelevantRoute />
+                            </Grid>
+                          )}
+                          exact
+                        />
+                        <Route path="/explorer" component={CoverCropExplorer} exact />
+                        <Route path="/about" component={About} exact />
+                        <Route path="/help" component={Help} exact />
+                        <Route path="/feedback" component={FeedbackComponent} exact />
+                        <Route path="/profile" component={Profile} exact />
+                        <Route path="/my-cover-crop-list" component={MyCoverCropListWrapper} exact />
+                        <Route path="/seeding-rate-calculator" component={SeedingRateCalculator} exact />
+                        <Route path="/data-dictionary" component={InformationSheetDictionary} exact />
+                        <Route path="/license" render={() => <License licenseType="MIT" />} exact />
+                        <Route
+                          path="/ag-informatics-license"
+                          render={() => <License licenseType="AgInformatics" />}
+                          exact
+                        />
+                        <Route path="/mix-maker" component={MixMaker} exact />
+
+                        <Route component={RouteNotFound} />
+                      </Switch>
+                    </Box>
+                  </Container>
+                </Box>
+                <Footer />
+              </Suspense>
+            </Auth0ProviderWithHistory>
+          </BrowserRouter>
+        </Provider>
+      </SnackbarProvider>
+    </ThemeProvider>
+  </StyledEngineProvider>
+
+);
+
+export default App;
+
+const LoadRelevantRoute = () => {
   const [calcHeight, setCalcHeight] = useState(0);
 
   const progressRedux = useSelector((stateRedux) => stateRedux.sharedData.progress);
@@ -34,28 +186,7 @@ const App = () => {
     setCalcHeight(calculatedHeight);
   }, []);
 
-  return (
-    <Box className="contentWrapper" id="mainContentWrapper">
-      <Header logo="neccc_wide_logo_color_web.jpg" />
-
-      <Container disableGutters maxWidth={false}>
-        <Box className="contentContainer">
-
-          <Grid container item xs={12} style={{ paddingLeft: 0, paddingRight: 0 }}>
-            <LoadRelevantRoute progress={progressRedux} calcHeight={calcHeight} />
-          </Grid>
-
-        </Box>
-      </Container>
-
-    </Box>
-  );
-};
-
-export default App;
-
-const LoadRelevantRoute = ({ progress, calcHeight }) => {
-  switch (progress) {
+  switch (progressRedux) {
     case 0:
       return (
         <Landing

--- a/src/components/MyCoverCropReset/MyCoverCropReset.js
+++ b/src/components/MyCoverCropReset/MyCoverCropReset.js
@@ -31,6 +31,7 @@ const MyCoverCropReset = ({
   };
 
   return (
+    // FIXME: this div shows to a white line under the Header on many pages
     <div className="container-fluid mt-5">
       <Dialog disableEscapeKeyDown open={handleConfirm}>
         <DialogContent dividers>

--- a/src/components/MyCoverCropReset/MyCoverCropReset.js
+++ b/src/components/MyCoverCropReset/MyCoverCropReset.js
@@ -6,32 +6,30 @@ import {
 } from '@mui/material';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { BinaryButton } from '../../shared/constants';
 import { reset } from '../../reduxStore/store';
+import { setMyCoverCropReset } from '../../reduxStore/sharedSlice';
 
-const MyCoverCropReset = ({
-  handleConfirm, setHandleConfirm, goBack = true, returnToHome = false,
-}) => {
+const MyCoverCropReset = () => {
   const dispatchRedux = useDispatch();
   const history = useHistory();
+  const { open, goBack } = useSelector((stateRedux) => stateRedux.sharedData.openMyCoverCropReset);
 
-  const handleConfirmChoice = (clearMyList = false) => {
-    if (clearMyList === true) {
+  const setOpen = (option) => {
+    if (option === true) {
       dispatchRedux(reset());
-      if (returnToHome) history.push('/');
-      // setSpeciesSelectorActivationFlag();
     } else if (goBack === true) {
       history.goBack();
       if (window.location.pathname !== '/') {
         history.push('/');
       }
     }
-    setHandleConfirm(false);
+    dispatchRedux(setMyCoverCropReset(false));
   };
 
   return (
-    <Dialog disableEscapeKeyDown open={handleConfirm}>
+    <Dialog disableEscapeKeyDown open={open}>
       <DialogContent dividers>
         <Typography variant="body1">
           In order to continue you will need to reset the My Cover Crop List. Would you like to continue?
@@ -39,7 +37,7 @@ const MyCoverCropReset = ({
       </DialogContent>
       <DialogActions>
         <BinaryButton
-          action={handleConfirmChoice}
+          action={setOpen}
         />
       </DialogActions>
     </Dialog>

--- a/src/components/MyCoverCropReset/MyCoverCropReset.js
+++ b/src/components/MyCoverCropReset/MyCoverCropReset.js
@@ -31,21 +31,18 @@ const MyCoverCropReset = ({
   };
 
   return (
-    // FIXME: this div shows to a white line under the Header on many pages
-    <div className="container-fluid mt-5">
-      <Dialog disableEscapeKeyDown open={handleConfirm}>
-        <DialogContent dividers>
-          <Typography variant="body1">
-            In order to continue you will need to reset the My Cover Crop List. Would you like to continue?
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <BinaryButton
-            action={handleConfirmChoice}
-          />
-        </DialogActions>
-      </Dialog>
-    </div>
+    <Dialog disableEscapeKeyDown open={handleConfirm}>
+      <DialogContent dividers>
+        <Typography variant="body1">
+          In order to continue you will need to reset the My Cover Crop List. Would you like to continue?
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <BinaryButton
+          action={handleConfirmChoice}
+        />
+      </DialogActions>
+    </Dialog>
   );
 };
 

--- a/src/components/WeatherConditions/WeatherConditions.js
+++ b/src/components/WeatherConditions/WeatherConditions.js
@@ -21,17 +21,14 @@ import { LightButton } from '../../shared/constants';
 import WeatherPrecipitation from './WeatherPrecipitation/WeatherPrecipitation';
 import WeatherFrostDates from './WeatherFrostDates/WeatherFrostDates';
 import WeatherFrostFreeDays from './WeatherFrostFreeDays/WeatherFrostFreeDays';
-import MyCoverCropReset from '../MyCoverCropReset/MyCoverCropReset';
 import { updateWeatherConditions } from '../../reduxStore/weatherSlice';
 
 const WeatherConditions = ({ caller }) => {
   const dispatchRedux = useDispatch();
 
   // redux vars
-  const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
   const weatherDataRedux = useSelector((stateRedux) => stateRedux.weatherData.weatherData);
   const ajaxInProgressRedux = useSelector((stateRedux) => stateRedux.sharedData.ajaxInProgress);
-  const myCoverCropListLocationRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropListLocation);
 
   // useState vars
   const [months, setMonths] = useState([]);
@@ -42,7 +39,6 @@ const WeatherConditions = ({ caller }) => {
   const [firstFrostDayHelper, setFirstFrostDayHelper] = useState('');
   const [firstFrostDayError, setFirstFrostDayError] = useState(false);
   const [lastFrostDayError, setLastFrostDayError] = useState(false);
-  const [handleConfirm, setHandleConfirm] = useState(false);
 
   const [firstFrostMonth, setFirstFrostMonth] = useState(
     weatherDataRedux?.averageFrost?.firstFrostDate?.month,
@@ -108,13 +104,6 @@ const WeatherConditions = ({ caller }) => {
     // data incorrect
     // show error on modal
   };
-
-  useEffect(() => {
-    if (myCoverCropListLocationRedux !== 'selector' && selectedCropsRedux.length > 0) {
-      // document.title = 'Cover Crop Selector';
-      setHandleConfirm(true);
-    }
-  }, [selectedCropsRedux, myCoverCropListLocationRedux]);
 
   useEffect(() => {
     // get current month in long form
@@ -559,7 +548,6 @@ const WeatherConditions = ({ caller }) => {
           </div>
         </Box>
       </Modal>
-      <MyCoverCropReset handleConfirm={handleConfirm} setHandleConfirm={setHandleConfirm} />
     </div>
   );
 };

--- a/src/components/WeatherConditions/WeatherConditions.js
+++ b/src/components/WeatherConditions/WeatherConditions.js
@@ -408,8 +408,8 @@ const MonthSelect = ({
           setValue(event.target.value);
         }}
         inputProps={{
-          name: { id },
-          id: { id },
+          name: id,
+          id,
         }}
       >
         {months.map((val, key) => (

--- a/src/index.js
+++ b/src/index.js
@@ -1,156 +1,16 @@
-/* eslint-disable react/no-unescaped-entities */
-/* eslint-disable import/extensions */
-/* eslint-disable react/no-unstable-nested-components */
 /*
   Index.js is the top level component
   styled using ./styles/parent.scss, ./styles/progressBar.css, CustomStyles from ./shared/constants
 */
 
-import React, { Suspense } from 'react';
-import { Provider } from 'react-redux';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
-import { BrowserRouter, Switch, Route } from 'react-router-dom';
-import {
-  ThemeProvider,
-  StyledEngineProvider,
-  responsiveFontSizes,
-  adaptV4Theme,
-} from '@mui/material';
-import { SnackbarProvider } from 'notistack';
-import { createTheme } from '@mui/material/styles';
+
 import App from './App';
 import * as serviceWorker from './serviceWorker';
-import './styles/parent.scss';
-import 'mdbreact/dist/css/mdb.css';
-import './styles/progressBar.css';
-import Footer from './pages/Footer/Footer';
-import About from './pages/About/About';
-import SeedingRateCalculator from './pages/SeedingRateCalculator/SeedingRateCalculator';
-import MixMaker from './pages/MixMaker/MixMaker';
-import CoverCropExplorer from './pages/CoverCropExplorer/CoverCropExplorer';
-import FeedbackComponent from './pages/Feedback/Feedback';
-import { CustomStyles } from './shared/constants';
-import InformationSheetDictionary from './pages/Help/InformationSheetDictionary/InformationSheetDictionary';
-import License from './pages/License/License';
-import MyCoverCropListWrapper from './pages/MyCoverCropList/MyCoverCropListWrapper/MyCoverCropListWrapper';
-import Help from './pages/Help/Help';
-import configureStore from './reduxStore/store';
-import Auth0ProviderWithHistory from './components/Auth/Auth0ProviderWithHistory/Auth0ProviderWithHistory';
-import Profile from './pages/Profile/Profile';
-import RouteNotFound from './pages/RouteNotFound/RouteNotFound';
 
-const withFooter = (WrappedComponent) => () => [<WrappedComponent key="1" />, <Footer key="2" />];
-const store = configureStore();
-
-// AdaptV4Theme has been depreciated and v5 is the new version.  TODO: look into update
-const theme = createTheme(
-  adaptV4Theme({
-    palette: {
-      primary: {
-        main: CustomStyles().lightGreen,
-      },
-      secondary: {
-        main: CustomStyles().lighterGreen,
-      },
-    },
-    overrides: {
-      MuiTooltip: {
-        tooltip: {
-          fontWeight: 'normal',
-          fontSize: CustomStyles().defaultFontSize,
-          backgroundColor: CustomStyles().secondaryProgressBtnColor,
-          color: 'black',
-          borderRadius: CustomStyles().mildlyRoundedRadius,
-        },
-        arrow: {},
-      },
-      MuiChip: {
-        root: {
-          '&&:hover': {
-            boxShadow: '0 0 3px 0 black',
-          },
-          border: '1px solid #777',
-        },
-        colorSecondary: {
-          '&, &&:hover, &&:focus': {
-            backgroundColor: CustomStyles().greenishWhite,
-            color: 'rgba(0,0,0,0.9)',
-            fontWeight: 'normal',
-          },
-        },
-        colorPrimary: {
-          '&, &&:hover, &&:focus': {
-            backgroundColor: CustomStyles().darkGreen,
-            color: 'white',
-            fontWeight: 'normal',
-          },
-        },
-        sizeSmall: {
-          fontSize: '1.2rem',
-        },
-      },
-      MuiDialog: {
-        root: {
-          zIndex: 1000003,
-        },
-      },
-    },
-  }),
-);
-
-const csTheme = responsiveFontSizes(theme, {
-  breakpoints: ['xs', 'sm', 'md', 'lg', 'xl'],
-});
-
-const Wrapper = () => (
-  <StyledEngineProvider injectFirst>
-    <ThemeProvider theme={csTheme}>
-      <SnackbarProvider
-        maxSnack={5}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
-        autoHideDuration={15000}
-      >
-        <Provider store={store}>
-          <BrowserRouter>
-            <Auth0ProviderWithHistory>
-              <Suspense fallback={<div>Loading..</div>}>
-                <Switch>
-                  <Route path="/" component={App} exact />
-                  <Route path="/explorer" component={CoverCropExplorer} exact />
-                  <Route path="/about" component={About} exact />
-                  <Route path="/help" component={Help} exact />
-                  <Route path="/feedback" component={FeedbackComponent} exact />
-                  <Route path="/profile" component={Profile} exact />
-                  <Route path="/my-cover-crop-list" component={MyCoverCropListWrapper} exact />
-                  <Route path="/seeding-rate-calculator" component={SeedingRateCalculator} exact />
-                  <Route path="/data-dictionary" component={InformationSheetDictionary} exact />
-                  <Route path="/license" component={() => <License licenseType="MIT" />} exact />
-                  <Route
-                    path="/ag-informatics-license"
-                    component={() => <License licenseType="AgInformatics" />}
-                    exact
-                  />
-                  <Route path="/mix-maker" component={MixMaker} exact />
-
-                  <Route component={RouteNotFound} />
-                </Switch>
-              </Suspense>
-            </Auth0ProviderWithHistory>
-            {/* <App /> */}
-          </BrowserRouter>
-        </Provider>
-      </SnackbarProvider>
-    </ThemeProvider>
-  </StyledEngineProvider>
-);
-
-const WrapperWithFooter = withFooter(Wrapper);
-
-ReactDOM.render(<WrapperWithFooter />, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/index.js
+++ b/src/index.js
@@ -15,10 +15,6 @@ import {
   ThemeProvider,
   StyledEngineProvider,
   responsiveFontSizes,
-  Grid,
-  Typography,
-  Container,
-  Link,
   adaptV4Theme,
 } from '@mui/material';
 import { SnackbarProvider } from 'notistack';
@@ -42,6 +38,7 @@ import Help from './pages/Help/Help';
 import configureStore from './reduxStore/store';
 import Auth0ProviderWithHistory from './components/Auth/Auth0ProviderWithHistory/Auth0ProviderWithHistory';
 import Profile from './pages/Profile/Profile';
+import RouteNotFound from './pages/RouteNotFound/RouteNotFound';
 
 const withFooter = (WrappedComponent) => () => [<WrappedComponent key="1" />, <Footer key="2" />];
 const store = configureStore();
@@ -100,35 +97,6 @@ const theme = createTheme(
       },
     },
   }),
-);
-const RouteNotFound = () => (
-  <section className="page_404">
-    <Container maxWidth="sm">
-      <Grid container justifyContent="center">
-        <Grid item xs={12}>
-          <div className="four_zero_four_bg">
-            <Typography variant="h1" component="h1" className="text-center">
-              404
-            </Typography>
-          </div>
-
-          <div className="contant_box_404" style={{ textAlign: 'center' }}>
-            <Typography variant="h3" component="h2">
-              Looks like you're lost
-            </Typography>
-
-            <Typography variant="body1">
-              The page you are looking for is not available!
-            </Typography>
-
-            <Link href="/" className="link_404">
-              Go Home
-            </Link>
-          </div>
-        </Grid>
-      </Grid>
-    </Container>
-  </section>
 );
 
 const csTheme = responsiveFontSizes(theme, {

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,13 @@
 */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-
+import { createRoot } from 'react-dom/client';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
+import './index.css';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/pages/About/About.js
+++ b/src/pages/About/About.js
@@ -240,8 +240,7 @@ const About = () => {
           ).
           <br />
           <br />
-          {/* FIXME: cannot add a <center> in <p> */}
-          <center>
+          <span style={{ display: 'inline-flex', justifyContent: 'center' }}>
             <img
               style={{
                 width: '70%',
@@ -252,7 +251,7 @@ const About = () => {
               src="/images/mockup.gif"
               alt="Decision Support Tool Mockup"
             />
-          </center>
+          </span>
           <br />
           <br />
           <b>Reusability:</b>

--- a/src/pages/About/About.js
+++ b/src/pages/About/About.js
@@ -12,7 +12,6 @@ import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import ReactGA from 'react-ga';
 import { CustomStyles } from '../../shared/constants';
-import Header from '../Header/Header';
 import MITLicenseText from '../License/MITLicenseText/MITLicenseText';
 
 const About = () => {
@@ -100,100 +99,102 @@ const About = () => {
         );
       case 1:
         return (
-          <Typography variant="body1" align="left">
-            The data featured in this tool are based on expert opinion. These data represent the
-            collective knowledge and experience of cover crop experts in the Northeast US.
-            Experts, grouped by their USDA hardiness zone, evaluated each cover crop property in
-            the dataset via deliberative discussions in over 70 teleconferences. The zones’
-            decisions on cover crop characteristics, notes regarding nuances and edge/special
-            cases, and framing of ratings were recorded in an online database. A comparative
-            analysis of the data across zones identified areas of inconsistencies which were then
-            addressed in a deliberative intra-regional discussion. This process, in conjunction
-            with feedback from users on the website, ensures the quality and improvement of the
-            data that powers the NECCC Species Selector. You can learn more about the
-            {' '}
-            <a
-              href="https://aginformaticslab.org/cover-crop-decision-tools/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              cover crop data verification process here
-            </a>
-            .
-            {' '}
-            <b>This work was made possible by the USDA</b>
-            <br />
-            <br />
-            <b>Data Sources:</b>
-            {' '}
-            The cover crop data were adapted from the
-            {' '}
-            <a href="http://mccc.msu.edu" target="_blank" rel="noopener noreferrer">
-              Midwest Cover Crops Council (MCCC) species selector tool
-            </a>
-            . These initial data have been reviewed, modified, and greatly expanded upon by cover
-            crop experts in the Northeast in each
-            {' '}
-            <a
-              href="https://planthardiness.ars.usda.gov/PHZMWeb/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              USDA plant hardiness zone
-            </a>
-            {' '}
-            to best match the cropping system types, goals, and constraints found in our region.
-            Additional data sources adapted for this tool include the
-            {' '}
-            <a
-              href="https://plants.sc.egov.usda.gov/java/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              USDA PLANTS database
-            </a>
-            {' '}
-            and a seeding rate calculator developed by USDA NRCS. These data are supplemented by
-            soils data available via
-            {' '}
-            <a
-              href="https://sdmdataaccess.nrcs.usda.gov/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              USDA NRCS Soil Data Access
-            </a>
-            , and weather data made available through an API, constructed by the Precision
-            Sustainable Agriculture team, serving
-            {' '}
-            <a
-              href="https://www.nssl.noaa.gov/projects/mrms/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              NSSL MRMS
-            </a>
-            {' '}
-            and
-            {' '}
-            <a href="https://ldas.gsfc.nasa.gov/nldas/" target="_blank" rel="noopener noreferrer">
-              NASA NLDAS-2
-            </a>
-            {' '}
-            weather data.
-            <br />
-            <br />
-            <b>Data Availability:</b>
-            {' '}
-            We are in the process of making our data publicly available
-            via a few mechanisms once we have completed beta-testing and finalized data quality
-            checks. In addition to accessing this data via the NECCC Species Selector Tool, users
-            will be able to download the raw data (spreadsheets) and Species Information Sheets
-            (PDFs).
-            <br />
-            <br />
+          <>
+            <Typography variant="body1" align="left">
+              The data featured in this tool are based on expert opinion. These data represent the
+              collective knowledge and experience of cover crop experts in the Northeast US.
+              Experts, grouped by their USDA hardiness zone, evaluated each cover crop property in
+              the dataset via deliberative discussions in over 70 teleconferences. The zones’
+              decisions on cover crop characteristics, notes regarding nuances and edge/special
+              cases, and framing of ratings were recorded in an online database. A comparative
+              analysis of the data across zones identified areas of inconsistencies which were then
+              addressed in a deliberative intra-regional discussion. This process, in conjunction
+              with feedback from users on the website, ensures the quality and improvement of the
+              data that powers the NECCC Species Selector. You can learn more about the
+              {' '}
+              <a
+                href="https://aginformaticslab.org/cover-crop-decision-tools/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                cover crop data verification process here
+              </a>
+              .
+              {' '}
+              <b>This work was made possible by the USDA</b>
+              <br />
+              <br />
+              <b>Data Sources:</b>
+              {' '}
+              The cover crop data were adapted from the
+              {' '}
+              <a href="http://mccc.msu.edu" target="_blank" rel="noopener noreferrer">
+                Midwest Cover Crops Council (MCCC) species selector tool
+              </a>
+              . These initial data have been reviewed, modified, and greatly expanded upon by cover
+              crop experts in the Northeast in each
+              {' '}
+              <a
+                href="https://planthardiness.ars.usda.gov/PHZMWeb/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                USDA plant hardiness zone
+              </a>
+              {' '}
+              to best match the cropping system types, goals, and constraints found in our region.
+              Additional data sources adapted for this tool include the
+              {' '}
+              <a
+                href="https://plants.sc.egov.usda.gov/java/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                USDA PLANTS database
+              </a>
+              {' '}
+              and a seeding rate calculator developed by USDA NRCS. These data are supplemented by
+              soils data available via
+              {' '}
+              <a
+                href="https://sdmdataaccess.nrcs.usda.gov/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                USDA NRCS Soil Data Access
+              </a>
+              , and weather data made available through an API, constructed by the Precision
+              Sustainable Agriculture team, serving
+              {' '}
+              <a
+                href="https://www.nssl.noaa.gov/projects/mrms/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                NSSL MRMS
+              </a>
+              {' '}
+              and
+              {' '}
+              <a href="https://ldas.gsfc.nasa.gov/nldas/" target="_blank" rel="noopener noreferrer">
+                NASA NLDAS-2
+              </a>
+              {' '}
+              weather data.
+              <br />
+              <br />
+              <b>Data Availability:</b>
+              {' '}
+              We are in the process of making our data publicly available
+              via a few mechanisms once we have completed beta-testing and finalized data quality
+              checks. In addition to accessing this data via the NECCC Species Selector Tool, users
+              will be able to download the raw data (spreadsheets) and Species Information Sheets
+              (PDFs).
+              <br />
+              <br />
+            </Typography>
             <MITLicenseText styles={false} aboutPage />
-          </Typography>
+          </>
         );
       case 2: return (
         <Typography variant="body1" align="left">
@@ -239,6 +240,7 @@ const About = () => {
           ).
           <br />
           <br />
+          {/* FIXME: cannot add a <center> in <p> */}
           <center>
             <img
               style={{
@@ -608,61 +610,58 @@ const About = () => {
   };
 
   return (
-    <div className="contentWrapper" id="mainContentWrapper">
-      <Header logo="neccc_wide_logo_color_web.jpg" />
-      <Box sx={{ border: 0.5, borderColor: 'grey.300' }} ml={2} mr={2} mt={5}>
-        <Grid container spacing={0} justifyContent="center" mt={4} mb={5} pt={3}>
-          <Grid item xs={12} sm={12} md={3.4} lg={3.4} xl={3.4}>
-            <div
-              style={{
-                border: `1px solid ${CustomStyles().darkGreen}`,
-                borderRight: '0px',
-              }}
-            >
-              {pageSections.map((section) => (
-                <Button
-                  key={section.id}
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    justifyContent: 'flex-start',
-                    borderRadius: '0px',
-                    width: '100%',
-                  }}
-                  onClick={() => handleChange(section.id)}
-                  variant={value === section.id ? 'contained' : 'text'}
-                >
-                  {section.menuOption}
-                </Button>
-              ))}
-            </div>
-          </Grid>
-
-          <Grid
-            item
-            xs={12}
-            sm={12}
-            md={8}
-            lg={8}
-            xl={8}
-            mt={{
-              xs: 3, sm: 3, md: 0, lg: 0, xl: 0,
+    <Box sx={{ border: 0.5, borderColor: 'grey.300' }} ml={2} mr={2} mt={5}>
+      <Grid container spacing={0} justifyContent="center" mt={4} mb={5} pt={3}>
+        <Grid item xs={12} sm={12} md={3.4} lg={3.4} xl={3.4}>
+          <div
+            style={{
+              border: `1px solid ${CustomStyles().darkGreen}`,
+              borderRight: '0px',
             }}
           >
-            <div style={{ border: `1px solid ${CustomStyles().darkGreen}`, minHeight: '320px' }}>
-              <Stack pl={3} pr={3} pb={4}>
-                <center>
-                  <Typography variant="h4" gutterBottom>
-                    {pageSections.filter((section) => section.id === value)[0].title}
-                  </Typography>
-                </center>
-                {getContent()}
-              </Stack>
-            </div>
-          </Grid>
+            {pageSections.map((section) => (
+              <Button
+                key={section.id}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  justifyContent: 'flex-start',
+                  borderRadius: '0px',
+                  width: '100%',
+                }}
+                onClick={() => handleChange(section.id)}
+                variant={value === section.id ? 'contained' : 'text'}
+              >
+                {section.menuOption}
+              </Button>
+            ))}
+          </div>
         </Grid>
-      </Box>
-    </div>
+
+        <Grid
+          item
+          xs={12}
+          sm={12}
+          md={8}
+          lg={8}
+          xl={8}
+          mt={{
+            xs: 3, sm: 3, md: 0, lg: 0, xl: 0,
+          }}
+        >
+          <div style={{ border: `1px solid ${CustomStyles().darkGreen}`, minHeight: '320px' }}>
+            <Stack pl={3} pr={3} pb={4}>
+              <center>
+                <Typography variant="h4" gutterBottom>
+                  {pageSections.filter((section) => section.id === value)[0].title}
+                </Typography>
+              </center>
+              {getContent()}
+            </Stack>
+          </div>
+        </Grid>
+      </Grid>
+    </Box>
   );
 };
 

--- a/src/pages/CoverCropExplorer/CoverCropExplorer.js
+++ b/src/pages/CoverCropExplorer/CoverCropExplorer.js
@@ -11,7 +11,6 @@ import { useHistory } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import ReactGA from 'react-ga';
-import Header from '../Header/Header';
 import ExplorerCardView from './ExplorerCardView/ExplorerCardView';
 import ConsentModal from './ConsentModal/ConsentModal';
 import CropSidebar from '../CropSidebar/CropSidebar';
@@ -91,9 +90,8 @@ const CoverCropExplorer = () => {
   }, [selectedCropsRedux, myCoverCropListLocationRedux]);
 
   return (
-    <div className="contentWrapper">
-      <ConsentModal consent={consentRedux} />
-      <Header logo="neccc_wide_logo_color_web.jpg" />
+    <>
+      <ConsentModal />
       <div className="container-fluid mt-4 mb-4">
         <div className="row mt-3">
           <div className="col-md-12 col-lg-3 col-xl-2 col-12">
@@ -122,7 +120,7 @@ const CoverCropExplorer = () => {
         </div>
       </div>
       <MyCoverCropReset handleConfirm={handleConfirm} setHandleConfirm={setHandleConfirm} />
-    </div>
+    </>
   );
 };
 

--- a/src/pages/CoverCropExplorer/CoverCropExplorer.js
+++ b/src/pages/CoverCropExplorer/CoverCropExplorer.js
@@ -14,7 +14,6 @@ import ReactGA from 'react-ga';
 import ExplorerCardView from './ExplorerCardView/ExplorerCardView';
 import ConsentModal from './ConsentModal/ConsentModal';
 import CropSidebar from '../CropSidebar/CropSidebar';
-import MyCoverCropReset from '../../components/MyCoverCropReset/MyCoverCropReset';
 import { updateRegion, updateStateInfo } from '../../reduxStore/mapSlice';
 
 const CoverCropExplorer = () => {
@@ -25,12 +24,9 @@ const CoverCropExplorer = () => {
   const sfilters = filterStateRedux[section];
   const activeCropDataRedux = useSelector((stateRedux) => stateRedux.cropData.activeCropData);
   const cropDataRedux = useSelector((stateRedux) => stateRedux.cropData.cropData);
-  const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
   const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
-  const myCoverCropListLocationRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropListLocation);
   const [updatedActiveCropData, setUpdatedActiveCropData] = useState([]);
   // const { activeCropData } = state;
-  const [handleConfirm, setHandleConfirm] = useState(false);
   const stateIdRedux = useSelector((stateRedux) => stateRedux.mapData.stateId);
 
   // open crop if url exists
@@ -82,13 +78,6 @@ const CoverCropExplorer = () => {
     }
   }, [stateIdRedux]);
 
-  useEffect(() => {
-    if (myCoverCropListLocationRedux !== 'explorer' && selectedCropsRedux?.length > 0) {
-      // document.title = 'Cover Crop Explorer';
-      setHandleConfirm(true);
-    }
-  }, [selectedCropsRedux, myCoverCropListLocationRedux]);
-
   return (
     <>
       <ConsentModal />
@@ -119,7 +108,6 @@ const CoverCropExplorer = () => {
           </div>
         </div>
       </div>
-      <MyCoverCropReset handleConfirm={handleConfirm} setHandleConfirm={setHandleConfirm} />
     </>
   );
 };

--- a/src/pages/CoverCropExplorer/ExplorerCardView/ExplorerCardView.js
+++ b/src/pages/CoverCropExplorer/ExplorerCardView/ExplorerCardView.js
@@ -7,7 +7,6 @@
 import {
   Grid, Typography, CircularProgress,
 } from '@mui/material';
-import { useSnackbar } from 'notistack';
 import React, {
   useEffect, useState,
 } from 'react';
@@ -36,8 +35,6 @@ const ExplorerCardView = ({ activeCropData }) => {
     setSelectedBtns(newSelectedBtns);
   }, [sfilters.zone, selectedCropsRedux]);
 
-  const { enqueueSnackbar } = useSnackbar();
-
   const handleModalOpen = (crop) => {
     // put data inside modal;
     setModalData(crop);
@@ -52,8 +49,7 @@ const ExplorerCardView = ({ activeCropData }) => {
 
     const buildDispatch = (action, crops) => {
       dispatchRedux(selectedCropsModifier(crops));
-      dispatchRedux(snackHandler({ snackOpen: false, snackMessage: `${cropName} ${action}` }));
-      enqueueSnackbar(`${cropName} ${action}`);
+      dispatchRedux(snackHandler({ snackOpen: true, snackMessage: `${cropName} ${action}` }));
     };
 
     if (selectedCropsRedux?.length > 0) {

--- a/src/pages/CropSelector/CropSelector.js
+++ b/src/pages/CropSelector/CropSelector.js
@@ -21,7 +21,6 @@ import MyCoverCropList from '../MyCoverCropList/MyCoverCropList';
 import CropCalendarView from './CropCalendarView/CropCalendarView';
 import CropSidebar from '../CropSidebar/CropSidebar';
 import CropTableComponent from './CropTable/CropTable';
-import MyCoverCropReset from '../../components/MyCoverCropReset/MyCoverCropReset';
 import { sortCrops } from '../../shared/constants';
 import { updateActiveCropData } from '../../reduxStore/cropSlice';
 import { updateProgress } from '../../reduxStore/sharedSlice';
@@ -60,11 +59,9 @@ const CropSelector = (props) => {
   // redux vars
   const activeCropDataRedux = useSelector((stateRedux) => stateRedux.cropData.activeCropData);
   const cropDataRedux = useSelector((stateRedux) => stateRedux.cropData.cropData);
-  const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
   const selectedGoalsRedux = useSelector((stateRedux) => stateRedux.goalsData.selectedGoals);
   const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
   const speciesSelectorActivationFlagRedux = useSelector((stateRedux) => stateRedux.sharedData.speciesSelectorActivationFlag);
-  const myCoverCropListLocationRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropListLocation);
 
   // useState vars
   const [showGrowthWindow, setShowGrowthWindow] = useState(true);
@@ -73,7 +70,6 @@ const CropSelector = (props) => {
   const [comparisonView, setComparisonView] = useState(false);
   const [cropData, setCropData] = useState([]);
   const [updatedActiveCropData, setUpdatedActiveCropData] = useState([]);
-  const [handleConfirm, setHandleConfirm] = useState(false);
 
   const sortCropsBy = (flag) => {
     const dispatchValue = (updatedCropData) => dispatchRedux(updateActiveCropData(updatedCropData));
@@ -86,12 +82,6 @@ const CropSelector = (props) => {
       dispatchValue(activeCropDataShadow);
     }
   };
-
-  useEffect(() => {
-    if (myCoverCropListLocationRedux !== 'selector' && selectedCropsRedux.length > 0) {
-      setHandleConfirm(true);
-    }
-  }, [selectedCropsRedux, myCoverCropListLocationRedux]);
 
   useEffect(() => {
     sortCropsBy(true);
@@ -243,7 +233,6 @@ const CropSelector = (props) => {
           <KeyboardArrowUp />
         </Fab>
       </ScrollTop>
-      <MyCoverCropReset handleConfirm={handleConfirm} setHandleConfirm={setHandleConfirm} />
     </Grid>
   );
 };

--- a/src/pages/CropSelector/CropTable/CropTableCard.js
+++ b/src/pages/CropSelector/CropTable/CropTableCard.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, TableCell, Tooltip } from '@mui/material';
-import { useSnackbar } from 'notistack';
 import { CustomStyles, getRating, LightButton } from '../../../shared/constants';
 import '../../../styles/cropCalendarViewComponent.scss';
 import '../../../styles/cropTable.scss';
@@ -13,7 +12,6 @@ const CropTableCard = ({
   crop, indexKey, showGrowthWindow, handleModalOpen,
 }) => {
   const dispatchRedux = useDispatch();
-  const { enqueueSnackbar } = useSnackbar();
   const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
   const selectedGoalsRedux = useSelector((stateRedux) => stateRedux.goalsData.selectedGoals);
 
@@ -21,8 +19,7 @@ const CropTableCard = ({
 
   const cropModifierAction = (selectedCrops, message) => {
     dispatchRedux(selectedCropsModifier(selectedCrops));
-    dispatchRedux(snackHandler({ snackOpen: false, snackMessage: message }));
-    enqueueSnackbar(message);
+    dispatchRedux(snackHandler({ snackOpen: true, snackMessage: message }));
   };
 
   const addCropToBasket = (cropId, cropName, btnId, cropData) => {

--- a/src/pages/CropSidebar/CropSidebar.js
+++ b/src/pages/CropSidebar/CropSidebar.js
@@ -339,6 +339,7 @@ const CropSidebar = ({
   ); // filterList
 
   useEffect(() => {
+    // FIXME: this function returns a compoennt in useEffect, not sure why doing that
     filtersList();
   }, [sidebarFilters]);
 

--- a/src/pages/Feedback/Feedback.js
+++ b/src/pages/Feedback/Feedback.js
@@ -11,7 +11,6 @@ import {
   FormGroup,
   FormControlLabel,
 } from '@mui/material';
-import Header from '../Header/Header';
 
 const FeedbackComponent = () => {
   const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
@@ -144,101 +143,99 @@ const FeedbackComponent = () => {
   };
 
   return (
-    <>
-      <Header />
-      <Grid
-        container
-        rowSpacing={5}
-        style={{
-          paddingLeft: '10%',
-          paddingRight: '10%',
-          paddingTop: '3%',
-          paddingBottom: '3%',
-        }}
-      >
-        {/* Title */}
-        <Grid container item spacing={1} justifyContent="center">
-          <Grid item xs={12}>
-            <Typography variant="h3">Cover Crop Species Selector Feedback</Typography>
-          </Grid>
+    <Grid
+      container
+      rowSpacing={5}
+      style={{
+        paddingLeft: '10%',
+        paddingRight: '10%',
+        paddingTop: '3%',
+        paddingBottom: '3%',
+      }}
+    >
+      {/* Title */}
+      <Grid container item spacing={1} justifyContent="center">
+        <Grid item xs={12}>
+          <Typography variant="h3">Cover Crop Species Selector Feedback</Typography>
         </Grid>
+      </Grid>
 
-        {/* Feedback Title */}
-        <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
-          <Grid item xs={12}>
-            <Typography variant="h6" display="inline-block">Title</Typography>
-            <Typography variant="h6" display="inline-block" style={{ color: 'red' }}>
-              *
-            </Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="body1">Give your feedback a short descriptive title.</Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <TextField
-              placeholder="Enter Your Title"
-              variant="outlined"
-              onChange={(event) => handleTextInputChange(event, 'title')}
+      {/* Feedback Title */}
+      <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
+        <Grid item xs={12}>
+          <Typography variant="h6" display="inline-block">Title</Typography>
+          <Typography variant="h6" display="inline-block" style={{ color: 'red' }}>
+            *
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography variant="body1">Give your feedback a short descriptive title.</Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
+            placeholder="Enter Your Title"
+            variant="outlined"
+            onChange={(event) => handleTextInputChange(event, 'title')}
+          />
+        </Grid>
+      </Grid>
+
+      {/* Feedback Messsage */}
+      <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
+        <Grid item xs={12}>
+          <Typography variant="h6" display="inline-block">Message </Typography>
+          <Typography variant="h6" display="inline-block" style={{ color: 'red' }}>
+            *
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography variant="body1">
+            Explain your feedback as thoroughly as you can. Your feedback will help us improve the
+            species selection experience. You can attach a screenshot of your feedback below.
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
+            placeholder="Enter Your Feedback"
+            multiline
+            variant="outlined"
+            fullWidth
+            minRows={3}
+            onChange={(event) => handleTextInputChange(event, 'comments')}
+          />
+        </Grid>
+      </Grid>
+
+      {/* Feedback Topic */}
+      <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
+        <Grid item xs={12}>
+          <Typography variant="h6" display="inline-block">Topic </Typography>
+          <Typography variant="h6" display="inline-block" style={{ color: 'red' }}>
+            *
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <Typography variant="body1">What is this feedback about?</Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <FormGroup>
+            <FormControlLabel
+              control={<Checkbox onChange={handleCheckboxChange} name="About the Cover Crop Data" />}
+              label="About the Cover Crop Data"
             />
-          </Grid>
-        </Grid>
-
-        {/* Feedback Messsage */}
-        <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
-          <Grid item xs={12}>
-            <Typography variant="h6" display="inline-block">Message </Typography>
-            <Typography variant="h6" display="inline-block" style={{ color: 'red' }}>
-              *
-            </Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="body1">
-              Explain your feedback as thoroughly as you can. Your feedback will help us improve the
-              species selection experience. You can attach a screenshot of your feedback below.
-            </Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <TextField
-              placeholder="Enter Your Feedback"
-              multiline
-              variant="outlined"
-              fullWidth
-              minRows={3}
-              onChange={(event) => handleTextInputChange(event, 'comments')}
+            <FormControlLabel
+              control={<Checkbox onChange={handleCheckboxChange} name="About the Website" />}
+              label="About the Website"
             />
-          </Grid>
+            <FormControlLabel
+              control={<Checkbox onChange={handleCheckboxChange} name="Other" />}
+              label="Other"
+            />
+          </FormGroup>
         </Grid>
+      </Grid>
 
-        {/* Feedback Topic */}
-        <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
-          <Grid item xs={12}>
-            <Typography variant="h6" display="inline-block">Topic </Typography>
-            <Typography variant="h6" display="inline-block" style={{ color: 'red' }}>
-              *
-            </Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <Typography variant="body1">What is this feedback about?</Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <FormGroup>
-              <FormControlLabel
-                control={<Checkbox onChange={handleCheckboxChange} name="About the Cover Crop Data" />}
-                label="About the Cover Crop Data"
-              />
-              <FormControlLabel
-                control={<Checkbox onChange={handleCheckboxChange} name="About the Website" />}
-                label="About the Website"
-              />
-              <FormControlLabel
-                control={<Checkbox onChange={handleCheckboxChange} name="Other" />}
-                label="Other"
-              />
-            </FormGroup>
-          </Grid>
-        </Grid>
-
-        {/* //Screenshot
+      {/* //Screenshot
         <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
           <Grid item xs={12}>
             <Typography variant="h6">Screen Shot Upload</Typography>
@@ -259,60 +256,59 @@ const FeedbackComponent = () => {
           </Grid>
         </Grid> */}
 
-        {/* Name */}
-        <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
-          <Grid item xs={12}>
-            <Typography variant="h6">Name </Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <TextField
-              placeholder="Enter Name"
-              variant="outlined"
-              onChange={(event) => handleTextInputChange(event, 'name')}
-            />
-          </Grid>
+      {/* Name */}
+      <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
+        <Grid item xs={12}>
+          <Typography variant="h6">Name </Typography>
         </Grid>
-
-        {/* Email */}
-        <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
-          <Grid item xs={12}>
-            <Typography variant="h6">Email </Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <TextField
-              placeholder="Enter Email"
-              variant="outlined"
-              onChange={(event) => handleTextInputChange(event, 'email')}
-            />
-          </Grid>
+        <Grid item xs={12}>
+          <TextField
+            placeholder="Enter Name"
+            variant="outlined"
+            onChange={(event) => handleTextInputChange(event, 'name')}
+          />
         </Grid>
-
-        {/* Submit */}
-        <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
-          {checkDisabled().state && (
-            <Grid item xs={12}>
-              <Typography variant="body1" style={{ color: 'red' }}>
-                {checkDisabled().message}
-                . Please fill all required fields before submitting.
-              </Typography>
-            </Grid>
-          )}
-          <Grid item xs={12}>
-            <Button disabled={checkDisabled().state} onClick={handleSubmit} size="large" variant="outlined">
-              Submit
-            </Button>
-          </Grid>
-        </Grid>
-        <Snackbar
-          open={snackbarData.open}
-          autoHideDuration={5000}
-          onClose={handleSnackbarClose}
-          message={snackbarData.message}
-          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-          color={snackbarData.color}
-        />
       </Grid>
-    </>
+
+      {/* Email */}
+      <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
+        <Grid item xs={12}>
+          <Typography variant="h6">Email </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <TextField
+            placeholder="Enter Email"
+            variant="outlined"
+            onChange={(event) => handleTextInputChange(event, 'email')}
+          />
+        </Grid>
+      </Grid>
+
+      {/* Submit */}
+      <Grid container item spacing={1} justifyContent="flex-start" alignItems="flex-start">
+        {checkDisabled().state && (
+        <Grid item xs={12}>
+          <Typography variant="body1" style={{ color: 'red' }}>
+            {checkDisabled().message}
+            . Please fill all required fields before submitting.
+          </Typography>
+        </Grid>
+        )}
+        <Grid item xs={12}>
+          <Button disabled={checkDisabled().state} onClick={handleSubmit} size="large" variant="outlined">
+            Submit
+          </Button>
+        </Grid>
+      </Grid>
+      <Snackbar
+        open={snackbarData.open}
+        autoHideDuration={5000}
+        onClose={handleSnackbarClose}
+        message={snackbarData.message}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        color={snackbarData.color}
+      />
+    </Grid>
   );
 };
 

--- a/src/pages/GoalsSelector/GoalsSelector.js
+++ b/src/pages/GoalsSelector/GoalsSelector.js
@@ -7,7 +7,6 @@
 import { Typography, Grid } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import MyCoverCropReset from '../../components/MyCoverCropReset/MyCoverCropReset';
 import '../../styles/goalsSelector.scss';
 import GoalTag from './GoalTag/GoalTag';
 import { callCoverCropApi } from '../../shared/constants';
@@ -22,21 +21,12 @@ const GoalsSelector = () => {
   // redux vars
   const regionIdRedux = useSelector((stateRedux) => stateRedux.mapData.regionId);
   const stateIdRedux = useSelector((stateRedux) => stateRedux.mapData.stateId);
-  const myCoverCropListLocationRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropListLocation);
   const apiBaseUrlRedux = useSelector((stateRedux) => stateRedux.sharedData.apiBaseUrl);
-  const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
   const allGoalsRedux = useSelector((stateRedux) => stateRedux.goalsData.allGoals);
 
   // useState vars
   const [allGoals, setAllGoals] = useState([]);
-  const [handleConfirm, setHandleConfirm] = useState(false);
 
-  useEffect(() => {
-    if (myCoverCropListLocationRedux !== 'selector' && selectedCropsRedux?.length > 0) {
-      // document.title = 'Cover Crop Selector';
-      setHandleConfirm(true);
-    }
-  }, [selectedCropsRedux, myCoverCropListLocationRedux]);
   const query = `${encodeURIComponent('regions')}=${encodeURIComponent(regionIdRedux)}`;
 
   useEffect(() => {
@@ -48,18 +38,17 @@ const GoalsSelector = () => {
   }, [allGoalsRedux]);
 
   return (
-    <>
-      <div className="goalsContainer" style={{ marginTop: '5%', width: '80%', marginLeft: '10%' }}>
-        <div className="goalsBoxContainer">
-          <Typography variant="h4" gutterBottom align="center">
-            What are your cover cropping goals?
-          </Typography>
-          <Typography variant="body2" align="center" color="secondary" gutterBottom>
-            Select up to three. The order in which you select your goals will determine the sorting of
-            cover crops. The first goal you select will have the highest priority in sorting and then
-            decrease for each additional goal. Hover on a goal for more information.
-          </Typography>
-          {allGoals?.length > 0 && (
+    <div className="goalsContainer" style={{ marginTop: '5%', width: '80%', marginLeft: '10%' }}>
+      <div className="goalsBoxContainer">
+        <Typography variant="h4" gutterBottom align="center">
+          What are your cover cropping goals?
+        </Typography>
+        <Typography variant="body2" align="center" color="secondary" gutterBottom>
+          Select up to three. The order in which you select your goals will determine the sorting of
+          cover crops. The first goal you select will have the highest priority in sorting and then
+          decrease for each additional goal. Hover on a goal for more information.
+        </Typography>
+        {allGoals?.length > 0 && (
           <Grid container spacing={4} className="goals" style={{ justifyContent: 'center' }}>
             {
                 allGoals.map((goal, key) => (
@@ -75,11 +64,9 @@ const GoalsSelector = () => {
                 ))
               }
           </Grid>
-          )}
-        </div>
+        )}
       </div>
-      <MyCoverCropReset handleConfirm={handleConfirm} setHandleConfirm={setHandleConfirm} />
-    </>
+    </div>
   );
 };
 

--- a/src/pages/Header/Header.js
+++ b/src/pages/Header/Header.js
@@ -6,7 +6,7 @@
 
 import { useDispatch, useSelector } from 'react-redux';
 import React, { useEffect, useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useHistory } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import '../../styles/header.scss';
 import HeaderLogoInfo from './HeaderLogoInfo/HeaderLogoInfo';
@@ -17,13 +17,20 @@ import { getFields } from '../../shared/constants';
 import AuthButton from '../../components/Auth/AuthButton/AuthButton';
 
 const Header = () => {
+  const [pathname, setPathname] = useState('/');
+  const history = useHistory();
   const dispatchRedux = useDispatch();
-  const markersRedux = useSelector((stateRedux) => stateRedux.addressData.markers);
   const progressRedux = useSelector((stateRedux) => stateRedux.sharedData.progress);
   const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
-  const [isRoot, setIsRoot] = useState(false);
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
-  const isActive = {};
+
+  useEffect(() => {
+    // detect current pathname
+    history.listen((location) => {
+      console.log('location', location.pathname);
+      setPathname(location.pathname);
+    });
+  }, [history]);
 
   useEffect(() => {
     const getToken = async () => {
@@ -34,22 +41,6 @@ const Header = () => {
     };
     if (isAuthenticated) getToken();
   }, [isAuthenticated, getAccessTokenSilently, consentRedux]);
-
-  useEffect(() => {
-    if (window.location.pathname === '/explorer') {
-      setIsRoot(true);
-    } else {
-      setIsRoot(false);
-    }
-
-    switch (progressRedux) {
-      case 0:
-        isActive.val = 0;
-        break;
-      default:
-        break;
-    }
-  }, [markersRedux]);
 
   return (
     <header className="d-print-none">
@@ -80,13 +71,12 @@ const Header = () => {
         <HeaderLogoInfo />
       </div>
       <div className="bottomHeader">
-        <ToggleOptions
-          isRoot={isRoot}
-        />
+        <ToggleOptions pathname={pathname} />
       </div>
 
-      <InformationBar />
+      <InformationBar pathname={pathname} />
 
+      {/* FIXME: this part of code will never render a div */}
       {window.location.pathname === '/about'
         || window.location.pathname === '/help'
         || (window.location.pathname === '/feedback'

--- a/src/pages/Header/Header.js
+++ b/src/pages/Header/Header.js
@@ -20,14 +20,12 @@ const Header = () => {
   const [pathname, setPathname] = useState('/');
   const history = useHistory();
   const dispatchRedux = useDispatch();
-  const progressRedux = useSelector((stateRedux) => stateRedux.sharedData.progress);
   const consentRedux = useSelector((stateRedux) => stateRedux.sharedData.consent);
   const { isAuthenticated, getAccessTokenSilently } = useAuth0();
 
   useEffect(() => {
     // detect current pathname
     history.listen((location) => {
-      console.log('location', location.pathname);
       setPathname(location.pathname);
     });
   }, [history]);
@@ -73,17 +71,7 @@ const Header = () => {
       <div className="bottomHeader">
         <ToggleOptions pathname={pathname} />
       </div>
-
       <InformationBar pathname={pathname} />
-
-      {/* FIXME: this part of code will never render a div */}
-      {window.location.pathname === '/about'
-        || window.location.pathname === '/help'
-        || (window.location.pathname === '/feedback'
-          && window.location.pathname !== '/cover-crop-explorer')
-        || (progressRedux < 0 && (
-          <div className="topBar" />
-        ))}
     </header>
   );
 };

--- a/src/pages/Header/Header.js
+++ b/src/pages/Header/Header.js
@@ -77,7 +77,7 @@ const Header = () => {
       </div>
 
       <div className="container-fluid">
-        <HeaderLogoInfo logo />
+        <HeaderLogoInfo />
       </div>
       <div className="bottomHeader">
         <ToggleOptions

--- a/src/pages/Header/Header.js
+++ b/src/pages/Header/Header.js
@@ -12,6 +12,7 @@ import '../../styles/header.scss';
 import HeaderLogoInfo from './HeaderLogoInfo/HeaderLogoInfo';
 import InformationBar from './InformationBar/InformationBar';
 import ToggleOptions from './ToggleOptions/ToggleOptions';
+import MyCoverCropReset from '../../components/MyCoverCropReset/MyCoverCropReset';
 import { updateAccessToken, updateField } from '../../reduxStore/userSlice';
 import { getFields } from '../../shared/constants';
 import AuthButton from '../../components/Auth/AuthButton/AuthButton';
@@ -72,6 +73,7 @@ const Header = () => {
         <ToggleOptions pathname={pathname} />
       </div>
       <InformationBar pathname={pathname} />
+      <MyCoverCropReset />
     </header>
   );
 };

--- a/src/pages/Header/HeaderLogoInfo/HeaderLogoInfo.js
+++ b/src/pages/Header/HeaderLogoInfo/HeaderLogoInfo.js
@@ -1,20 +1,19 @@
 import {
   Typography, Box, Grid,
 } from '@mui/material';
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { reset } from '../../../reduxStore/store';
 import '../../../styles/header.scss';
 import DateComponent from '../DateComponent/DateComponent';
 import ForecastComponent from '../ForecastComponent/ForecastComponent';
-import MyCoverCropReset from '../../../components/MyCoverCropReset/MyCoverCropReset';
+import { setMyCoverCropReset } from '../../../reduxStore/sharedSlice';
 
 const HeaderLogoInfo = () => {
   const dispatchRedux = useDispatch();
   const history = useHistory();
   const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
-  const [handleConfirm, setHandleConfirm] = useState(false);
   const councilLabelRedux = useSelector((stateRedux) => stateRedux.mapData.councilLabel);
 
   const handleClick = () => {
@@ -23,7 +22,7 @@ const HeaderLogoInfo = () => {
         dispatchRedux(reset());
       } else history.replace('/');
     } else {
-      setHandleConfirm(true);
+      dispatchRedux(setMyCoverCropReset(true, false));
     }
   };
 
@@ -119,7 +118,6 @@ const HeaderLogoInfo = () => {
         </div>
       </Grid>
 
-      <MyCoverCropReset handleConfirm={handleConfirm} setHandleConfirm={setHandleConfirm} goBack={false} returnToHome />
     </Grid>
   );
 };

--- a/src/pages/Header/HeaderLogoInfo/HeaderLogoInfo.js
+++ b/src/pages/Header/HeaderLogoInfo/HeaderLogoInfo.js
@@ -18,9 +18,8 @@ const HeaderLogoInfo = () => {
 
   const handleClick = () => {
     if (selectedCropsRedux.length === 0) {
-      if (window.location.pathname === '/') {
-        dispatchRedux(reset());
-      } else history.replace('/');
+      dispatchRedux(reset());
+      history.replace('/');
     } else {
       dispatchRedux(setMyCoverCropReset(true, false));
     }

--- a/src/pages/Header/InformationBar/InformationBar.js
+++ b/src/pages/Header/InformationBar/InformationBar.js
@@ -29,7 +29,7 @@ const expansionPanelBaseStyle = {
   alignItems: 'center',
 };
 
-const InformationBar = () => {
+const InformationBar = ({ pathname }) => {
   const dispatchRedux = useDispatch();
   const addressRedux = useSelector((stateRedux) => stateRedux.addressData.address);
   const zoneRedux = useSelector((stateRedux) => stateRedux.addressData.zone);
@@ -170,7 +170,7 @@ const InformationBar = () => {
   return (
     <div className="greenBarParent" id="greenBarParent">
       <div className="greenBarWrapper">
-        {window.location.pathname === speciesSelectorToolName && (
+        {pathname === speciesSelectorToolName && (
         <Grid
           container
         >
@@ -206,6 +206,7 @@ const InformationBar = () => {
         </Grid>
         )}
       </div>
+      {/* FIXME: this part of codes seems not used */}
       <div
         className="greenBarExpansionPanel container-fluid pl-0 pr-0"
         id="greenBarExpansionPanel"

--- a/src/pages/Header/InformationBar/InformationBar.js
+++ b/src/pages/Header/InformationBar/InformationBar.js
@@ -12,10 +12,9 @@ import { LocationOn } from '@mui/icons-material';
 import CloudIcon from '@mui/icons-material/Cloud';
 import CheckIcon from '@mui/icons-material/Check';
 import FilterHdrIcon from '@mui/icons-material/FilterHdr';
-import React, { useState } from 'react';
+import React from 'react';
 import '../../../styles/greenBar.scss';
 import ProgressButtons from '../../../shared/ProgressButtons';
-import MyCoverCropReset from '../../../components/MyCoverCropReset/MyCoverCropReset';
 import { gotoProgress } from '../../../reduxStore/sharedSlice';
 
 const speciesSelectorToolName = '/';
@@ -28,9 +27,6 @@ const InformationBar = ({ pathname }) => {
   const weatherDataRedux = useSelector((stateRedux) => stateRedux.weatherData.weatherData);
   const soilDataRedux = useSelector((stateRedux) => stateRedux.soilData.soilData);
   const progressRedux = useSelector((stateRedux) => stateRedux.sharedData.progress);
-
-  // useState vars
-  const [handleConfirm, setHandleConfirm] = useState(false);
 
   // functions
   const handleBtnClick = (type) => {
@@ -177,12 +173,11 @@ const InformationBar = ({ pathname }) => {
             md={12}
             lg={2.5}
           >
-            <ProgressButtons setConfirmationOpen={setHandleConfirm} />
+            <ProgressButtons />
           </Grid>
         </Grid>
         )}
       </div>
-      <MyCoverCropReset handleConfirm={handleConfirm} setHandleConfirm={setHandleConfirm} goBack={false} />
     </div>
   );
 };

--- a/src/pages/Header/InformationBar/InformationBar.js
+++ b/src/pages/Header/InformationBar/InformationBar.js
@@ -14,20 +14,11 @@ import CheckIcon from '@mui/icons-material/Check';
 import FilterHdrIcon from '@mui/icons-material/FilterHdr';
 import React, { useState } from 'react';
 import '../../../styles/greenBar.scss';
-import LocationComponent from '../../Location/Location';
-import SoilCondition from '../../Location/SoilCondition/SoilCondition';
-import WeatherConditions from '../../../components/WeatherConditions/WeatherConditions';
 import ProgressButtons from '../../../shared/ProgressButtons';
 import MyCoverCropReset from '../../../components/MyCoverCropReset/MyCoverCropReset';
 import { gotoProgress } from '../../../reduxStore/sharedSlice';
 
 const speciesSelectorToolName = '/';
-
-const expansionPanelBaseStyle = {
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-};
 
 const InformationBar = ({ pathname }) => {
   const dispatchRedux = useDispatch();
@@ -40,23 +31,8 @@ const InformationBar = ({ pathname }) => {
 
   // useState vars
   const [handleConfirm, setHandleConfirm] = useState(false);
-  const [expansionPanelComponent, setExpansionPanelComponent] = useState({
-    component: '',
-  });
-
-  // const vars
-  const defaultMarkers = [[40.78489145, -74.80733626930342]];
 
   // functions
-  const closeExpansionPanel = () => {
-    const greenbarExpansionElement = document.getElementById('greenBarExpansionPanel');
-    greenbarExpansionElement.style.transform = 'translate(0px,0px)';
-    greenbarExpansionElement.style.minHeight = '0px';
-    setExpansionPanelComponent({
-      component: '',
-    });
-  };
-
   const handleBtnClick = (type) => {
     const options = {
       location: 1,
@@ -201,60 +177,10 @@ const InformationBar = ({ pathname }) => {
             md={12}
             lg={2.5}
           >
-            <ProgressButtons closeExpansionPanel={closeExpansionPanel} setConfirmationOpen={setHandleConfirm} />
+            <ProgressButtons setConfirmationOpen={setHandleConfirm} />
           </Grid>
         </Grid>
         )}
-      </div>
-      {/* FIXME: this part of codes seems not used */}
-      <div
-        className="greenBarExpansionPanel container-fluid pl-0 pr-0"
-        id="greenBarExpansionPanel"
-      >
-        <div className="row justify-content-center align-items-center">
-          <div
-            className={expansionPanelComponent.component === 'location' ? 'col-md-10' : 'col-md-6'}
-          >
-            {expansionPanelComponent.component === 'location' && (
-              <LocationComponent caller="greenbar" title="Location" defaultMarkers={defaultMarkers} closeExpansionPanel={closeExpansionPanel} />
-            )}
-            {expansionPanelComponent.component === 'soil' && (
-              <div className="container mt-5" style={expansionPanelBaseStyle}>
-                <div className="row boxContainerRow" style={{ minHeight: '526px' }}>
-                  <SoilCondition caller="greenbar" />
-                </div>
-              </div>
-            )}
-            {expansionPanelComponent.component === 'weather' && (
-              <div className="container mt-5" style={expansionPanelBaseStyle}>
-                <div className="row boxContainerRow" style={{ minHeight: '526px' }}>
-                  <WeatherConditions caller="greenbar" />
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-        <div
-          className="d-flex justify-content-center"
-          style={expansionPanelComponent.component === '' ? { height: '0px' } : { height: '50px' }}
-        >
-          {expansionPanelComponent.component !== '' && (
-            <div
-              className="pt-2 pb-2"
-              style={{
-                position: 'absolute',
-                bottom: '-30px',
-                textAlign: 'center',
-                width: '100%',
-                background: 'linear-gradient(to top, #506147, #598344)',
-              }}
-            >
-              <Button variant="contained" onClick={closeExpansionPanel}>
-                Close
-              </Button>
-            </div>
-          )}
-        </div>
       </div>
       <MyCoverCropReset handleConfirm={handleConfirm} setHandleConfirm={setHandleConfirm} goBack={false} />
     </div>

--- a/src/pages/Header/ToggleOptions/ToggleOptions.js
+++ b/src/pages/Header/ToggleOptions/ToggleOptions.js
@@ -5,7 +5,7 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { NavLink, useHistory } from 'react-router-dom';
 import '../../../styles/header.scss';
-import { activateMyCoverCropListTile, activateSpeicesSelectorTile } from '../../../reduxStore/sharedSlice';
+import { activateMyCoverCropListTile, activateSpeicesSelectorTile, setMyCoverCropReset } from '../../../reduxStore/sharedSlice';
 
 const ToggleOptions = ({ pathname }) => {
   const dispatchRedux = useDispatch();
@@ -24,7 +24,16 @@ const ToggleOptions = ({ pathname }) => {
     }
   };
 
+  const openMyCoverCropReset = (to) => {
+    if (selectedCropsRedux.length > 0
+      && ((pathname === '/' && to === 'explorer')
+      || (pathname === '/explorer' && to === 'selector'))) {
+      dispatchRedux(setMyCoverCropReset(true));
+    }
+  };
+
   const setSpeciesSelectorActivationFlag = () => {
+    openMyCoverCropReset('explorer');
     dispatchRedux(activateSpeicesSelectorTile({ speciesSelectorActivationFlag: true, myCoverCropActivationFlag: false }));
     if (pathname !== '/explorer') {
       history.push('/explorer');
@@ -33,7 +42,7 @@ const ToggleOptions = ({ pathname }) => {
 
   return (
     <>
-      <Button size="large" component={NavLink} exact to="/" activeClassName="active">
+      <Button size="large" component={NavLink} onClick={() => openMyCoverCropReset('selector')} exact to="/" activeClassName="active">
         SPECIES SELECTOR TOOL
       </Button>
       <Tooltip title={(stateLabelRedux === null) ? 'You must select a state before using the Cover Crop Explorer' : ''}>

--- a/src/pages/Header/ToggleOptions/ToggleOptions.js
+++ b/src/pages/Header/ToggleOptions/ToggleOptions.js
@@ -7,7 +7,7 @@ import { NavLink, useHistory } from 'react-router-dom';
 import '../../../styles/header.scss';
 import { activateMyCoverCropListTile, activateSpeicesSelectorTile } from '../../../reduxStore/sharedSlice';
 
-const ToggleOptions = ({ isRoot }) => {
+const ToggleOptions = ({ pathname }) => {
   const dispatchRedux = useDispatch();
   const history = useHistory();
   const stateLabelRedux = useSelector((stateRedux) => stateRedux.mapData.stateLabel);
@@ -17,7 +17,8 @@ const ToggleOptions = ({ isRoot }) => {
   const speciesSelectorActivationFlagRedux = useSelector((stateRedux) => stateRedux.sharedData.speciesSelectorActivationFlag);
   const setMyCoverCropActivationFlag = () => {
     history.push('/my-cover-crop-list');
-    if (window.location.pathname === '/explorer') {
+    // FIXME: the following codes will not work?
+    if (pathname === '/explorer') {
       if (progressRedux > 4) {
         dispatchRedux(activateMyCoverCropListTile({ myCoverCropActivationFlag: true, speciesSelectorActivationFlag: false }));
       }
@@ -26,36 +27,30 @@ const ToggleOptions = ({ isRoot }) => {
 
   const setSpeciesSelectorActivationFlag = () => {
     dispatchRedux(activateSpeicesSelectorTile({ speciesSelectorActivationFlag: true, myCoverCropActivationFlag: false }));
-    if (window.location.pathname !== '/explorer') {
+    if (pathname !== '/explorer') {
       history.push('/explorer');
-    }
-  };
-
-  const clearMyCoverCropList = (selector = false) => {
-    if (selector) {
-      setSpeciesSelectorActivationFlag();
     }
   };
 
   return (
     <>
-      <Button size="large" onClick={() => clearMyCoverCropList(false)} component={NavLink} exact to="/" activeClassName="active">
+      <Button size="large" component={NavLink} exact to="/" activeClassName="active">
         SPECIES SELECTOR TOOL
       </Button>
-      <Tooltip title={(stateLabelRedux === null || stateLabelRedux === '') ? 'You must select a state before using the Cover Crop Explorer' : ''}>
+      <Tooltip title={(stateLabelRedux === null) ? 'You must select a state before using the Cover Crop Explorer' : ''}>
         <span>
           <Button
-            className={(isRoot && speciesSelectorActivationFlagRedux) ? 'active' : ''}
-            onClick={() => clearMyCoverCropList(true)}
+            className={(pathname === '/explorer' && speciesSelectorActivationFlagRedux) ? 'active' : ''}
+            onClick={setSpeciesSelectorActivationFlag}
             size="large"
-            disabled={stateLabelRedux === null || stateLabelRedux === ''}
+            disabled={stateLabelRedux === null}
           >
             COVER CROP EXPLORER
           </Button>
         </span>
       </Tooltip>
 
-      {window.location.pathname === '/'
+      {pathname === '/'
         && selectedCropsRedux.length > 0
          && (
          <Badge
@@ -65,7 +60,7 @@ const ToggleOptions = ({ isRoot }) => {
            <Button
              size="large"
              className={
-                (myCoverCropActivationFlagRedux && window.location.pathname === '/')
+                (myCoverCropActivationFlagRedux && pathname === '/')
                   && 'active'
               }
              onClick={setMyCoverCropActivationFlag}
@@ -75,14 +70,14 @@ const ToggleOptions = ({ isRoot }) => {
          </Badge>
          )}
       {/* My Cover Crop List As A Separate Component/Route  */}
-      {window.location.pathname !== '/' && (
+      {pathname !== '/' && (
         selectedCropsRedux.length > 0 && (
           <Badge
             badgeContent={selectedCropsRedux.length}
             color="error"
           >
             <Button
-              className={window.location.pathname === '/my-cover-crop-list' && 'active'}
+              className={pathname === '/my-cover-crop-list' && 'active'}
               onClick={() => history.push('/my-cover-crop-list')}
             >
               My Cover Crop List

--- a/src/pages/Header/ToggleOptions/ToggleOptions.js
+++ b/src/pages/Header/ToggleOptions/ToggleOptions.js
@@ -1,13 +1,14 @@
 import {
   Badge, Button, Tooltip,
 } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { NavLink, useHistory } from 'react-router-dom';
 import '../../../styles/header.scss';
 import { activateMyCoverCropListTile, activateSpeicesSelectorTile, setMyCoverCropReset } from '../../../reduxStore/sharedSlice';
 
 const ToggleOptions = ({ pathname }) => {
+  const [prevRoute, setPrevRoute] = useState('selector');
   const dispatchRedux = useDispatch();
   const history = useHistory();
   const stateLabelRedux = useSelector((stateRedux) => stateRedux.mapData.stateLabel);
@@ -25,11 +26,9 @@ const ToggleOptions = ({ pathname }) => {
   };
 
   const openMyCoverCropReset = (to) => {
-    if (selectedCropsRedux.length > 0
-      && ((pathname === '/' && to === 'explorer')
-      || (pathname === '/explorer' && to === 'selector'))) {
+    if (selectedCropsRedux.length > 0 && prevRoute !== to) {
       dispatchRedux(setMyCoverCropReset(true));
-    }
+    } else setPrevRoute(to);
   };
 
   const setSpeciesSelectorActivationFlag = () => {
@@ -65,6 +64,7 @@ const ToggleOptions = ({ pathname }) => {
           color="error"
         >
           <Button
+            className={pathname === '/my-cover-crop-list' ? 'active' : ''}
             size="large"
             onClick={setMyCoverCropActivationFlag}
           >

--- a/src/pages/Header/ToggleOptions/ToggleOptions.js
+++ b/src/pages/Header/ToggleOptions/ToggleOptions.js
@@ -12,7 +12,6 @@ const ToggleOptions = ({ pathname }) => {
   const history = useHistory();
   const stateLabelRedux = useSelector((stateRedux) => stateRedux.mapData.stateLabel);
   const progressRedux = useSelector((stateRedux) => stateRedux.sharedData.progress);
-  const myCoverCropActivationFlagRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropActivationFlag);
   const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
   const speciesSelectorActivationFlagRedux = useSelector((stateRedux) => stateRedux.sharedData.speciesSelectorActivationFlag);
   const setMyCoverCropActivationFlag = () => {
@@ -50,41 +49,20 @@ const ToggleOptions = ({ pathname }) => {
         </span>
       </Tooltip>
 
-      {pathname === '/'
-        && selectedCropsRedux.length > 0
-         && (
-         <Badge
-           badgeContent={selectedCropsRedux.length}
-           color="error"
-         >
-           <Button
-             size="large"
-             className={
-                (myCoverCropActivationFlagRedux && pathname === '/')
-                  && 'active'
-              }
-             onClick={setMyCoverCropActivationFlag}
-           >
-             MY COVER CROP LIST
-           </Button>
-         </Badge>
-         )}
-      {/* My Cover Crop List As A Separate Component/Route  */}
-      {pathname !== '/' && (
-        selectedCropsRedux.length > 0 && (
-          <Badge
-            badgeContent={selectedCropsRedux.length}
-            color="error"
+      {selectedCropsRedux.length > 0
+        && (
+        <Badge
+          badgeContent={selectedCropsRedux.length}
+          color="error"
+        >
+          <Button
+            size="large"
+            onClick={setMyCoverCropActivationFlag}
           >
-            <Button
-              className={pathname === '/my-cover-crop-list' && 'active'}
-              onClick={() => history.push('/my-cover-crop-list')}
-            >
-              My Cover Crop List
-            </Button>
-          </Badge>
-        )
-      )}
+            MY COVER CROP LIST
+          </Button>
+        </Badge>
+        )}
     </>
   );
 };

--- a/src/pages/Help/Help.js
+++ b/src/pages/Help/Help.js
@@ -15,7 +15,6 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import ReactGA from 'react-ga';
 import { CustomStyles } from '../../shared/constants';
-import Header from '../Header/Header';
 import InformationSheetDictionary from './InformationSheetDictionary/InformationSheetDictionary';
 
 const Help = () => {
@@ -386,61 +385,58 @@ const Help = () => {
   };
 
   return (
-    <div className="contentWrapper">
-      <Header />
-      <Box sx={{ border: 0.5, borderColor: 'grey.300' }} ml={2} mr={2} mt={5}>
-        <Grid container spacing={0} justifyContent="center" mt={4} mb={5} pt={3}>
-          <Grid item xs={12} sm={12} md={3.4} lg={3.4} xl={3.4}>
-            <div
-              style={{
-                border: `1px solid ${CustomStyles().darkGreen}`,
-                borderRight: '0px',
-              }}
-            >
-              {pageSections.map((section) => (
-                <Button
-                  key={section.id}
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    justifyContent: 'flex-start',
-                    borderRadius: '0px',
-                    width: '100%',
-                  }}
-                  onClick={() => handleChange(section.id)}
-                  variant={value === section.id ? 'contained' : 'text'}
-                >
-                  {section.menuOption}
-                </Button>
-              ))}
-            </div>
-          </Grid>
-
-          <Grid
-            item
-            xs={12}
-            sm={12}
-            md={8}
-            lg={8}
-            xl={8}
-            mt={{
-              xs: 3, sm: 3, md: 0, lg: 0, xl: 0,
+    <Box sx={{ border: 0.5, borderColor: 'grey.300' }} ml={2} mr={2} mt={5}>
+      <Grid container spacing={0} justifyContent="center" mt={4} mb={5} pt={3}>
+        <Grid item xs={12} sm={12} md={3.4} lg={3.4} xl={3.4}>
+          <div
+            style={{
+              border: `1px solid ${CustomStyles().darkGreen}`,
+              borderRight: '0px',
             }}
           >
-            <div style={{ border: `1px solid ${CustomStyles().darkGreen}`, minHeight: '320px' }}>
-              <Stack pl={3} pr={3} pb={4}>
-                <center>
-                  <Typography variant="h4" gutterBottom>
-                    {pageSections.filter((section) => section.id === value)[0].title}
-                  </Typography>
-                </center>
-                {getContent()}
-              </Stack>
-            </div>
-          </Grid>
+            {pageSections.map((section) => (
+              <Button
+                key={section.id}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  justifyContent: 'flex-start',
+                  borderRadius: '0px',
+                  width: '100%',
+                }}
+                onClick={() => handleChange(section.id)}
+                variant={value === section.id ? 'contained' : 'text'}
+              >
+                {section.menuOption}
+              </Button>
+            ))}
+          </div>
         </Grid>
-      </Box>
-    </div>
+
+        <Grid
+          item
+          xs={12}
+          sm={12}
+          md={8}
+          lg={8}
+          xl={8}
+          mt={{
+            xs: 3, sm: 3, md: 0, lg: 0, xl: 0,
+          }}
+        >
+          <div style={{ border: `1px solid ${CustomStyles().darkGreen}`, minHeight: '320px' }}>
+            <Stack pl={3} pr={3} pb={4}>
+              <center>
+                <Typography variant="h4" gutterBottom>
+                  {pageSections.filter((section) => section.id === value)[0].title}
+                </Typography>
+              </center>
+              {getContent()}
+            </Stack>
+          </div>
+        </Grid>
+      </Grid>
+    </Box>
   );
 };
 

--- a/src/pages/Landing/Landing.js
+++ b/src/pages/Landing/Landing.js
@@ -24,7 +24,6 @@ import { useAuth0 } from '@auth0/auth0-react';
 import { callCoverCropApi } from '../../shared/constants';
 import '../../styles/landing.scss';
 import ConsentModal from '../CoverCropExplorer/ConsentModal/ConsentModal';
-import MyCoverCropReset from '../../components/MyCoverCropReset/MyCoverCropReset';
 // import { updateZone } from '../../reduxStore/addressSlice';
 import AuthModal from './AuthModal/AuthModal';
 import { updateRegions, updateRegion, updateStateInfo } from '../../reduxStore/mapSlice';
@@ -38,14 +37,11 @@ const Landing = ({ height, title, bg }) => {
   const regionsRedux = useSelector((stateRedux) => stateRedux.mapData.regions);
   const stateIdRedux = useSelector((stateRedux) => stateRedux.mapData.stateId);
   const councilLabelRedux = useSelector((stateRedux) => stateRedux.mapData.councilLabel);
-  const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
   const consentRedux = useSelector((stateRedux) => stateRedux.userData.consent);
-  const myCoverCropListLocationRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropListLocation);
   const apiBaseUrlRedux = useSelector((stateRedux) => stateRedux.sharedData.apiBaseUrl);
   const hideConsentRedux = useSelector((stateRedux) => stateRedux.userData.hideConsentModal);
 
   // useState vars
-  const [handleConfirm, setHandleConfirm] = useState(false);
   const [containerHeight, setContainerHeight] = useState(height);
   const [allStates, setAllStates] = useState([]);
   // This is the state obj mapped by mapState
@@ -203,9 +199,6 @@ const Landing = ({ height, title, bg }) => {
 
   useEffect(() => {
     document.title = 'Cover Crop Selector';
-    if (myCoverCropListLocationRedux !== 'selector' && selectedCropsRedux.length > 0) {
-      setHandleConfirm(true);
-    }
   }, []);
 
   return (
@@ -345,7 +338,6 @@ const Landing = ({ height, title, bg }) => {
           </Grid>
         </Grid>
       </Grid>
-      <MyCoverCropReset handleConfirm={handleConfirm} setHandleConfirm={setHandleConfirm} />
     </div>
   );
 };

--- a/src/pages/License/License.js
+++ b/src/pages/License/License.js
@@ -5,7 +5,6 @@
 
 import { Grid } from '@mui/material';
 import React, { useEffect } from 'react';
-import Header from '../Header/Header';
 import MITLicenseText from './MITLicenseText/MITLicenseText';
 import AgInformaticsLicenseText from './AgInformaticsLicenseText/AgInformaticsLicenseText';
 
@@ -24,15 +23,12 @@ const License = ({ licenseType = 'MIT' }) => {
     }
   }, [licenseType]);
   return (
-    <div className="contentWrapper" id="mainContentWrapper">
-      <Header logo="neccc_wide_logo_color_web.jpg" />
-      <div className="container-fluid mt-5">
-        <Grid container>
-          <Grid item>
-            {licenseType === 'AgInformatics' ? <AgInformaticsLicenseText /> : <MITLicenseText />}
-          </Grid>
+    <div className="container-fluid mt-5">
+      <Grid container>
+        <Grid item>
+          {licenseType === 'AgInformatics' ? <AgInformaticsLicenseText /> : <MITLicenseText />}
         </Grid>
-      </div>
+      </Grid>
     </div>
   );
 };

--- a/src/pages/Location/Location.js
+++ b/src/pages/Location/Location.js
@@ -24,7 +24,6 @@ import {
   abbrRegion, reverseGEO, callCoverCropApi, postFields, getFields,
   buildPoint, buildGeometryCollection, drawAreaFromGeoCollection, deleteFields,
 } from '../../shared/constants';
-import MyCoverCropReset from '../../components/MyCoverCropReset/MyCoverCropReset';
 import PlantHardinessZone from '../CropSidebar/PlantHardinessZone/PlantHardinessZone';
 import {
   changeAddressViaMap, updateLocation,
@@ -57,21 +56,18 @@ const LocationComponent = () => {
   // redux vars
   const countyRedux = useSelector((stateRedux) => stateRedux.addressData.county);
   const zoneRedux = useSelector((stateRedux) => stateRedux.addressData.zone);
-  const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
   const markersRedux = useSelector((stateRedux) => stateRedux.addressData.markers);
   const regionsRedux = useSelector((stateRedux) => stateRedux.mapData.regions);
   const stateLabelRedux = useSelector((stateRedux) => stateRedux.mapData.stateLabel);
   const councilShorthandRedux = useSelector((stateRedux) => stateRedux.mapData.councilShorthand);
   const councilLabelRedux = useSelector((stateRedux) => stateRedux.mapData.councilLabel);
   const progressRedux = useSelector((stateRedux) => stateRedux.sharedData.progress);
-  const myCoverCropListLocationRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropListLocation);
   const regionShorthand = useSelector((stateRedux) => stateRedux.mapData.regionShorthand);
   const accessTokenRedux = useSelector((stateRedux) => stateRedux.userData.accessToken);
   const userFieldRedux = useSelector((stateRedux) => stateRedux.userData.field);
   const selectedFieldRedux = useSelector((stateRedux) => stateRedux.userData.selectedField);
 
   // useState vars
-  const [handleConfirm, setHandleConfirm] = useState(false);
   const [selectedZone, setselectedZone] = useState();
   const [locZipCode, setLocZipCode] = useState();
   const [selectedToEditSite, setSelectedToEditSite] = useState({});
@@ -128,12 +124,6 @@ const LocationComponent = () => {
     }
     return [47, -122];
   }, [stateLabelRedux]);
-
-  useEffect(() => {
-    if (selectedCropsRedux.length > 0) {
-      setHandleConfirm(true);
-    }
-  }, [selectedCropsRedux, myCoverCropListLocationRedux]);
 
   const updateReg = (region) => {
     if (region !== undefined) {
@@ -502,7 +492,6 @@ const LocationComponent = () => {
           </div>
         </div>
       </div>
-      <MyCoverCropReset handleConfirm={handleConfirm} setHandleConfirm={setHandleConfirm} from="selector" />
       <UserFieldDialog
         fieldDialogState={fieldDialogState}
         setFieldDialogState={setFieldDialogState}

--- a/src/pages/Location/SoilCondition/SoilDrainage/SoilDrainage.js
+++ b/src/pages/Location/SoilCondition/SoilDrainage/SoilDrainage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Button, Typography } from '@mui/material';
 import { LocalDrinkOutlined } from '@mui/icons-material';
@@ -6,7 +6,6 @@ import { ReferenceTooltip } from '../../../../shared/constants';
 import arrayEquals from '../../../../shared/functions';
 import '../../../../styles/soilConditions.scss';
 import RenderDrainageClasses from './RenderDrainageClasses';
-import MyCoverCropReset from '../../../../components/MyCoverCropReset/MyCoverCropReset';
 import { updateDrainageClass as updateDrainageClassRedux } from '../../../../reduxStore/soilSlice';
 
 const SoilDrainage = ({ setTilingCheck }) => {
@@ -15,18 +14,6 @@ const SoilDrainage = ({ setTilingCheck }) => {
   // redux vars
   const soilDataRedux = useSelector((stateRedux) => stateRedux.soilData.soilData);
   const soilDataOriginalRedux = useSelector((stateRedux) => stateRedux.soilData.soilDataOriginal);
-  const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
-  const myCoverCropListLocationRedux = useSelector((stateRedux) => stateRedux.sharedData.myCoverCropListLocation);
-
-  // useState vars
-  const [handleConfirm, setHandleConfirm] = useState(false);
-
-  useEffect(() => {
-    if (myCoverCropListLocationRedux !== 'selector' && selectedCropsRedux.length > 0) {
-      // document.title = 'Cover Crop Selector';
-      setHandleConfirm(true);
-    }
-  }, [selectedCropsRedux, myCoverCropListLocationRedux]);
 
   const resetDrainageClasses = () => {
     dispatchRedux(updateDrainageClassRedux(soilDataOriginalRedux?.drainageClass));
@@ -98,7 +85,6 @@ const SoilDrainage = ({ setTilingCheck }) => {
       <div className="col-12">
         <RenderDrainageClasses drainage={soilDataRedux?.drainageClass} />
       </div>
-      <MyCoverCropReset handleConfirm={handleConfirm} setHandleConfirm={setHandleConfirm} />
     </div>
   );
 };

--- a/src/pages/MixMaker/MixMaker.js
+++ b/src/pages/MixMaker/MixMaker.js
@@ -5,13 +5,9 @@
 import { Box } from '@mui/material';
 import React from 'react';
 import { UnderConstructionText } from '../../shared/constants';
-import Header from '../Header/Header';
 
 const MixMaker = () => (
-  <div className="contentWrapper">
-    <Header logo="neccc_wide_logo_color_web.jpg" />
-    <Box>{UnderConstructionText}</Box>
-  </div>
+  <Box>{UnderConstructionText}</Box>
 );
 
 export default MixMaker;

--- a/src/pages/MyCoverCropList/MyCoverCropCards/MyCoverCropCards.js
+++ b/src/pages/MyCoverCropList/MyCoverCropCards/MyCoverCropCards.js
@@ -6,7 +6,6 @@
 */
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useSnackbar } from 'notistack';
 import CropCard from '../../../components/CropCard/CropCard';
 import CropDetailsModal from '../../../components/CropDetailsModal/CropDetailsModal';
 import { selectedCropsModifier } from '../../../reduxStore/cropSlice';
@@ -16,7 +15,6 @@ const MyCoverCropCards = ({ data, cardNo }) => {
   const dispatchRedux = useDispatch();
   const [modalOpen, setModalOpen] = useState(false);
   const [modalData, setModalData] = useState({});
-  const { enqueueSnackbar } = useSnackbar();
   const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
   const removeCrop = (cropName, id) => {
     let removeIndex = -1;
@@ -34,8 +32,7 @@ const MyCoverCropCards = ({ data, cardNo }) => {
 
       selectedCropsCopy.splice(removeIndex, 1);
       dispatchRedux(selectedCropsModifier(selectedCropsCopy));
-      dispatchRedux(snackHandler({ snackOpen: false, snackMessage: 'Removed' }));
-      enqueueSnackbar(`${cropName} Removed`);
+      dispatchRedux(snackHandler({ snackOpen: true, snackMessage: `${cropName} Removed` }));
     }
   };
 

--- a/src/pages/MyCoverCropList/MyCoverCropComparison/MyCoverCropComparison.js
+++ b/src/pages/MyCoverCropList/MyCoverCropComparison/MyCoverCropComparison.js
@@ -16,7 +16,6 @@ import {
   Typography,
 } from '@mui/material';
 import { KeyboardArrowLeft, KeyboardArrowRight } from '@mui/icons-material';
-import { useSnackbar } from 'notistack';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -65,7 +64,6 @@ const GetAverageGoalRating = ({ crop }) => {
 
 const MyCoverCropComparison = ({ selectedCrops }) => {
   const dispatchRedux = useDispatch();
-  const { enqueueSnackbar } = useSnackbar();
 
   // redux vars
   const selectedGoalsRedux = useSelector((stateRedux) => stateRedux.goalsData.selectedGoals);
@@ -115,8 +113,7 @@ const MyCoverCropComparison = ({ selectedCrops }) => {
 
       selectedCropsCopy.splice(removeIndex, 1);
       dispatchRedux(selectedCropsModifier(selectedCropsCopy));
-      dispatchRedux(snackHandler({ snackOpen: false, snackMessage: 'Removed' }));
-      enqueueSnackbar(`${cropName} Removed`);
+      dispatchRedux(snackHandler({ snackOpen: true, snackMessage: `${cropName} Removed` }));
     }
   };
 

--- a/src/pages/MyCoverCropList/MyCoverCropListWrapper/MyCoverCropListWrapper.js
+++ b/src/pages/MyCoverCropList/MyCoverCropListWrapper/MyCoverCropListWrapper.js
@@ -6,7 +6,6 @@
 import { Grid } from '@mui/material';
 import React, { useState } from 'react';
 import CropSidebar from '../../CropSidebar/CropSidebar';
-import Header from '../../Header/Header';
 import MyCoverCropList from '../MyCoverCropList';
 
 const MyCoverCropListWrapper = () => {
@@ -16,9 +15,6 @@ const MyCoverCropListWrapper = () => {
   };
   return (
     <Grid container spacing={5}>
-      <Grid item xl={12} lg={12} md={12}>
-        <Header />
-      </Grid>
 
       {/* <Grid container spacing={5}> */}
       <Grid item xl={3} lg={3} md={3}>

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -6,57 +6,53 @@
 import { Box } from '@mui/material';
 import { useAuth0 } from '@auth0/auth0-react';
 import React from 'react';
-import Header from '../Header/Header';
 
 const Profile = () => {
   const { user, isAuthenticated } = useAuth0();
 
   return (
-    <div className="contentWrapper" id="mainContentWrapper">
-      <Header />
-      <Box sx={{ border: 0.5, borderColor: 'grey.300' }} ml={2} mr={2} mt={5}>
-        {isAuthenticated ? (
+    <Box sx={{ border: 0.5, borderColor: 'grey.300' }} ml={2} mr={2} mt={5}>
+      {isAuthenticated ? (
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'auto 1fr',
+          columnGap: '16px',
+        }}
+        >
+          <img
+            src={user.picture}
+            alt="Profile"
+            style={{
+              borderRadius: '50%',
+              height: '80px',
+              width: '80px',
+            }}
+          />
           <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'auto 1fr',
-            columnGap: '16px',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-around',
           }}
           >
-            <img
-              src={user.picture}
-              alt="Profile"
-              style={{
-                borderRadius: '50%',
-                height: '80px',
-                width: '80px',
-              }}
-            />
-            <div style={{
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'space-around',
+            <h2 style={{
+              marginTop: 0,
+              marginBottom: 0,
             }}
             >
-              <h2 style={{
-                marginTop: 0,
-                marginBottom: 0,
-              }}
-              >
-                {user.name}
-              </h2>
-              <span style={{
-                fontSize: '1.3rem',
-              }}
-              >
-                {user.email}
-              </span>
-            </div>
+              {user.name}
+            </h2>
+            <span style={{
+              fontSize: '1.3rem',
+            }}
+            >
+              {user.email}
+            </span>
           </div>
-        ) : (
-          <div>You have not been logged in!</div>
-        )}
-      </Box>
-    </div>
+        </div>
+      ) : (
+        <div>You have not been logged in!</div>
+      )}
+    </Box>
 
   );
 };

--- a/src/pages/RouteNotFound/RouteNotFound.js
+++ b/src/pages/RouteNotFound/RouteNotFound.js
@@ -1,0 +1,39 @@
+import {
+  Grid,
+  Typography,
+  Container,
+  Link,
+} from '@mui/material';
+import React from 'react';
+
+const RouteNotFound = () => (
+  <section className="page_404">
+    <Container maxWidth="sm">
+      <Grid container justifyContent="center">
+        <Grid item xs={12}>
+          <div className="four_zero_four_bg">
+            <Typography variant="h1" component="h1" className="text-center">
+              404
+            </Typography>
+          </div>
+
+          <div className="contant_box_404" style={{ textAlign: 'center' }}>
+            <Typography variant="h3" component="h2">
+              Looks like you&apos;re lost
+            </Typography>
+
+            <Typography variant="body1">
+              The page you are looking for is not available!
+            </Typography>
+
+            <Link href="/" className="link_404">
+              Go Home
+            </Link>
+          </div>
+        </Grid>
+      </Grid>
+    </Container>
+  </section>
+);
+
+export default RouteNotFound;

--- a/src/pages/SeedingRateCalculator/SeedingRateCalculator.js
+++ b/src/pages/SeedingRateCalculator/SeedingRateCalculator.js
@@ -5,13 +5,9 @@
 import { Box } from '@mui/material';
 import React from 'react';
 import { UnderConstructionText } from '../../shared/constants';
-import Header from '../Header/Header';
 
 const SeedingRateCalculator = () => (
-  <div className="contentWrapper">
-    <Header logo="neccc_wide_logo_color_web.jpg" />
-    <Box>{UnderConstructionText}</Box>
-  </div>
+  <Box>{UnderConstructionText}</Box>
 );
 
 export default SeedingRateCalculator;

--- a/src/reduxStore/sharedSlice.js
+++ b/src/reduxStore/sharedSlice.js
@@ -14,6 +14,10 @@ const initialState = {
   apiBaseUrl: /(localhost|dev)/i.test(window.location)
     ? 'developapi'
     : 'api',
+  openMyCoverCropReset: {
+    open: false,
+    goBack: true,
+  },
 };
 
 export const updateProgress = (value) => ({
@@ -89,6 +93,14 @@ export const pullDictionaryData = (value) => ({
   },
 });
 
+export const setMyCoverCropReset = (open, goBack = true) => ({
+  type: 'SET_MY_COVER_CROP_RESET',
+  payload: {
+    open,
+    goBack,
+  },
+});
+
 const sharedReducer = (state = initialState, action = null) => {
   switch (action.type) {
     case 'UPDATE_PROGRESS':
@@ -157,6 +169,15 @@ const sharedReducer = (state = initialState, action = null) => {
         dataDictionary: action.payload.value,
       };
     }
+
+    case 'SET_MY_COVER_CROP_RESET':
+      return {
+        ...state,
+        openMyCoverCropReset: {
+          open: action.payload.open,
+          goBack: action.payload.goBack,
+        },
+      };
 
     default:
       return { ...state };

--- a/src/shared/ProgressButtons.js
+++ b/src/shared/ProgressButtons.js
@@ -7,7 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import ProgressButtonsInner from './ProgressButtonsInner';
 
-const ProgressButtons = ({ closeExpansionPanel, setConfirmationOpen }) => {
+const ProgressButtons = ({ setConfirmationOpen }) => {
   const addressRedux = useSelector((stateRedux) => stateRedux.addressData.address);
   const selectedGoalsRedux = useSelector((stateRedux) => stateRedux.goalsData.selectedGoals);
   const filterStateRedux = useSelector((stateRedux) => stateRedux.filterData);
@@ -62,7 +62,6 @@ const ProgressButtons = ({ closeExpansionPanel, setConfirmationOpen }) => {
         isDisabledBack={disabledBack}
         isDisabledNext={disabledNext}
         isDisabledRefresh={disabledRefresh}
-        closeExpansionPanel={closeExpansionPanel}
         setConfirmationOpen={setConfirmationOpen}
       />
     );

--- a/src/shared/ProgressButtons.js
+++ b/src/shared/ProgressButtons.js
@@ -7,7 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import ProgressButtonsInner from './ProgressButtonsInner';
 
-const ProgressButtons = ({ setConfirmationOpen }) => {
+const ProgressButtons = () => {
   const addressRedux = useSelector((stateRedux) => stateRedux.addressData.address);
   const selectedGoalsRedux = useSelector((stateRedux) => stateRedux.goalsData.selectedGoals);
   const filterStateRedux = useSelector((stateRedux) => stateRedux.filterData);
@@ -62,7 +62,6 @@ const ProgressButtons = ({ setConfirmationOpen }) => {
         isDisabledBack={disabledBack}
         isDisabledNext={disabledNext}
         isDisabledRefresh={disabledRefresh}
-        setConfirmationOpen={setConfirmationOpen}
       />
     );
   };

--- a/src/shared/ProgressButtonsInner.js
+++ b/src/shared/ProgressButtonsInner.js
@@ -12,7 +12,7 @@ import { reset } from '../reduxStore/store';
 import { updateProgress } from '../reduxStore/sharedSlice';
 
 const ProgressButtonsInner = ({
-  isDisabledBack, isDisabledNext, isDisabledRefresh, closeExpansionPanel, setConfirmationOpen,
+  isDisabledBack, isDisabledNext, isDisabledRefresh, setConfirmationOpen,
 }) => {
   const dispatchRedux = useDispatch();
   const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
@@ -80,7 +80,6 @@ const ProgressButtonsInner = ({
           marginLeft: '3%',
         }}
         onClick={() => {
-          closeExpansionPanel();
           if (selectedCropsRedux.length > 0) setConfirmationOpen(true);
           else {
             dispatchRedux(reset());

--- a/src/shared/ProgressButtonsInner.js
+++ b/src/shared/ProgressButtonsInner.js
@@ -9,10 +9,10 @@ import { Stack } from '@mui/material';
 import { useSelector, useDispatch } from 'react-redux';
 import { LightButton } from './constants';
 import { reset } from '../reduxStore/store';
-import { updateProgress } from '../reduxStore/sharedSlice';
+import { updateProgress, setMyCoverCropReset } from '../reduxStore/sharedSlice';
 
 const ProgressButtonsInner = ({
-  isDisabledBack, isDisabledNext, isDisabledRefresh, setConfirmationOpen,
+  isDisabledBack, isDisabledNext, isDisabledRefresh,
 }) => {
   const dispatchRedux = useDispatch();
   const selectedCropsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCrops);
@@ -80,8 +80,9 @@ const ProgressButtonsInner = ({
           marginLeft: '3%',
         }}
         onClick={() => {
-          if (selectedCropsRedux.length > 0) setConfirmationOpen(true);
-          else {
+          if (selectedCropsRedux.length > 0) {
+            dispatchRedux(setMyCoverCropReset(true, false));
+          } else {
             dispatchRedux(reset());
           }
         }}

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -286,12 +286,6 @@ export const getRating = (ratng) => {
 
 export const allMonths = moment().localeData().monthsShort();
 
-export const greenBarExpansionPanelHeight = {
-  large: '600px',
-  medium: '600px',
-  small: '600px',
-};
-
 export const trimString = (stringFull, size) => {
   if (!Number.isNaN(size)) {
     return `${stringFull.substring(0, size)}${stringFull.length > 25 ? '...' : ''}`;

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -901,6 +901,7 @@ export const getFields = async (accessToken = null) => {
   };
   return fetch(url, config)
     .then((res) => res.json())
+    // eslint-disable-next-line no-console
     .catch((err) => console.log(err));
 };
 
@@ -916,6 +917,7 @@ export const postFields = async (accessToken = null, fieldsData = null) => {
   };
   return fetch(url, config)
     .then((res) => res.json())
+    // eslint-disable-next-line no-console
     .catch((err) => console.log(err));
 };
 
@@ -930,6 +932,7 @@ export const deleteFields = async (accessToken = null, id = null) => {
   };
   return fetch(url, config)
     .then((res) => res.json())
+    // eslint-disable-next-line no-console
     .catch((err) => console.log(err));
 };
 

--- a/src/styles/greenBar.scss
+++ b/src/styles/greenBar.scss
@@ -36,13 +36,4 @@ $lighterGreen: #598445;
 
 .greenBarParent {
   width: 100%;
-  .greenBarExpansionPanel {
-    // height: 0px;
-    background-color: $darkGreen;
-    width: 100%;
-    z-index: 1001;
-    position: absolute;
-    transition: height 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-    // animation: min-height 3s linear;
-  }
 }

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -245,16 +245,6 @@ header {
       // font-weight: bold;
     }
   }
-  .topBar {
-    background: $primaryProgressBtnColor;
-    height: 10px;
-    width: 100%;
-  }
-  .topBarMuted {
-    background: #fff;
-    height: 10px;
-    width: 100%;
-  }
 }
 
 // hamburgur


### PR DESCRIPTION
- Moved index codes into App.
- Modified a lot of files which have header component in them. Now the Header is outside of router and is only used in App.js.
- removed notistack library used in many components, now all snackbars are from MUI and controlled by redux state.
- Changed the logic of getting window.location.pathname in Header and its child components to make the logic same as before.
- Deleted several unused codes.
- Refactored MyCoverCropReset, delete multiple this component in other components, move the control logic into redux.