### PR TITLE
Fix modal padding in authmodal.js

### DIFF
--- a/src/pages/CoverCropExplorer/ConsentModal/ConsentModal.js
+++ b/src/pages/CoverCropExplorer/ConsentModal/ConsentModal.js
@@ -15,11 +15,18 @@ const ConsentModal = ({ modalOpen, setModalOpen }) => {
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
-    maxWidth: '80%',
+    maxWidth: {
+      xs: '90%', sm: '80%', md: '80%', lg: '80%', xl: '80%',
+    },
+    minWidth: {
+      xs: '90%', sm: 'auto', md: 'auto', lg: 'auto', xl: 'auto',
+    },
     bgcolor: 'background.paper',
     border: '2px solid #000',
     boxShadow: 24,
-    p: 4,
+    p: {
+      xs: 2, sm: 2, md: 3, lg: 4, xl: 4,
+    },
   };
 
   useEffect(() => {

--- a/src/pages/Landing/AuthModal/AuthModal.js
+++ b/src/pages/Landing/AuthModal/AuthModal.js
@@ -34,7 +34,6 @@ const AuthModal = ({ modalOpen, setModalOpen, setConsentModalOpen }) => {
     bgcolor: 'background.paper',
     border: '2px solid #000',
     boxShadow: 24,
-    p: 4,
   };
 
   const handleModal = () => {
@@ -55,7 +54,12 @@ const AuthModal = ({ modalOpen, setModalOpen, setConsentModalOpen }) => {
       closeAfterTransition
       onClose={handleModal}
     >
-      <Box sx={style}>
+      <Box
+        sx={style}
+        p={{
+          xs: 2, sm: 2, md: 3, lg: 4, xl: 4,
+        }}
+      >
         <Typography variant="h6" component="h2">
           Login to try out our new user history feature?
         </Typography>

--- a/src/pages/Landing/AuthModal/AuthModal.js
+++ b/src/pages/Landing/AuthModal/AuthModal.js
@@ -28,12 +28,20 @@ const AuthModal = ({ modalOpen, setModalOpen, setConsentModalOpen }) => {
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
-    maxWidth: '80%',
+    maxWidth: {
+      xs: '90%', sm: '80%', md: '80%', lg: '80%', xl: '80%',
+    },
+    minWidth: {
+      xs: '90%', sm: 'auto', md: 'auto', lg: 'auto', xl: 'auto',
+    },
     marginTop: '15px',
     marginBottom: '15px',
     bgcolor: 'background.paper',
     border: '2px solid #000',
     boxShadow: 24,
+    p: {
+      xs: 2, sm: 2, md: 3, lg: 4, xl: 4,
+    },
   };
 
   const handleModal = () => {
@@ -56,9 +64,6 @@ const AuthModal = ({ modalOpen, setModalOpen, setConsentModalOpen }) => {
     >
       <Box
         sx={style}
-        p={{
-          xs: 2, sm: 2, md: 3, lg: 4, xl: 4,
-        }}
       >
         <Typography variant="h6" component="h2">
           Login to try out our new user history feature?


### PR DESCRIPTION
This PR has fixes for issue https://github.com/precision-sustainable-ag/dst-selector/issues/510

The modal after changing the padding from 4 to 2 looks as below:
![image](https://github.com/precision-sustainable-ag/dst-selector/assets/51780939/921c451a-9572-4b18-9f96-4ffa8f72e701)