### PR TITLE
Update feature when user select region

### DIFF
--- a/src/pages/CropSidebar/PlantHardinessZone/PlantHardinessZone.js
+++ b/src/pages/CropSidebar/PlantHardinessZone/PlantHardinessZone.js
@@ -3,6 +3,9 @@ import {
   Collapse, FormControl, InputLabel, List, ListItem, MenuItem, Select, Typography,
 } from '@mui/material';
 import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { userSelectRegion } from '../../../reduxStore/userSlice';
+import statesLatLongDict from '../../../shared/stateslatlongdict';
 // import { useSelector } from 'react-redux';
 
 const PlantHardinessZone = ({
@@ -12,6 +15,10 @@ const PlantHardinessZone = ({
   councilLabelRedux,
   regionToggleRedux = true,
 }) => {
+  const dispatchRedux = useDispatch();
+  const markersRedux = useSelector((stateRedux) => stateRedux.addressData.markers);
+  const stateLabelRedux = useSelector((stateRedux) => stateRedux.mapData.stateLabel);
+
   const plantHardinessZone = () => (
     <Select
       variant="filled"
@@ -22,7 +29,18 @@ const PlantHardinessZone = ({
         textAlign: 'left',
       }}
       sx={{ minWidth: 200 }}
-      onChange={(e) => setRegionShorthand(e.target.value)}
+      onChange={(e) => {
+        setRegionShorthand(e.target.value);
+        if (markersRedux
+          && (markersRedux[0][1] === statesLatLongDict[stateLabelRedux][1]
+         && markersRedux[0][0] === statesLatLongDict[stateLabelRedux][0])) {
+          // set redux to true (means user select another region while didn't change address)
+          dispatchRedux(userSelectRegion(true));
+        } else {
+          // if user changed marker, not set redux
+          dispatchRedux(userSelectRegion(false));
+        }
+      }}
       value={regionShorthand || ''}
       error={!regionShorthand}
     >

--- a/src/pages/Location/SoilCondition/SoilCondition.js
+++ b/src/pages/Location/SoilCondition/SoilCondition.js
@@ -24,6 +24,7 @@ const SoilCondition = () => {
   const soilDataOriginalRedux = useSelector((stateRedux) => stateRedux.soilData.soilDataOriginal);
   // const councilShorthandRedux = useSelector((stateRedux) => stateRedux.mapData.councilShorthand);
   const stateLabelRedux = useSelector((stateRedux) => stateRedux.mapData.stateLabel);
+  const userSelectRegionRedux = useSelector((stateRedux) => stateRedux.userData.userSelectRegion);
 
   // useState vars
 
@@ -138,6 +139,8 @@ const SoilCondition = () => {
     const lat = markersRedux[0][0];
     const lon = markersRedux[0][1];
 
+    // if the user selected another region, not run the function
+    if (userSelectRegionRedux) return;
     if (stateLabelRedux === 'Ontario') return;
 
     if (soilDataOriginalRedux?.latLong) {

--- a/src/reduxStore/userSlice.js
+++ b/src/reduxStore/userSlice.js
@@ -6,6 +6,7 @@ const initialState = {
     date: null,
   },
   selectedFieldId: null,
+  userSelectRegion: false,
 };
 
 export const updateAccessToken = (token) => ({
@@ -28,6 +29,12 @@ export const setSelectFieldId = (fieldId) => ({
   payload: { fieldId },
 });
 
+// eslint-disable-next-line no-shadow
+export const userSelectRegion = (userSelectRegion) => ({
+  type: 'USER_SELECT_REGION',
+  payload: { userSelectRegion },
+});
+
 const userReducer = (state = initialState, action = null) => {
   switch (action.type) {
     case 'UPDATE_ACCESSTOKEN':
@@ -45,6 +52,8 @@ const userReducer = (state = initialState, action = null) => {
       };
     case 'SELECT_FIELD':
       return { ...state, selectedFieldId: action.payload.fieldId };
+    case 'USER_SELECT_REGION':
+      return { ...state, userSelectRegion: action.payload.userSelectRegion };
     default:
       return { ...state };
   }


### PR DESCRIPTION
If user select a different region on capitol address, delete the marker in redux so on site condition it does not use capitol to populate data. If the user use a different location, this would not work.
