### PR TITLE
updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:18 as builder
 WORKDIR /usr/src/app
 COPY package.json package.json
-COPY . .
 RUN npm install
+COPY . .
 RUN npm run build 
 
 FROM nginx:1.23.1-alpine


### PR DESCRIPTION
- this change is done to speed image rebuild
- this will skip intermediate image creation when no package.json changes are present, instead it will use cached image where npm install is already done

