### PR TITLE
Selector: Misspelling in the Additional Filters Box #861

### DIFF
--- a/src/pages/GoalsSelector/GoalsSelector.jsx
+++ b/src/pages/GoalsSelector/GoalsSelector.jsx
@@ -267,7 +267,7 @@ const GoalsSelector = () => {
         >
           <Grid item xs={12}>
             <Typography variant="h5" align="center" data-test="title-goals">
-              Coover Crop Planting Season
+              Cover Crop Planting Season
             </Typography>
           </Grid>
           {/* sub-title */}


### PR DESCRIPTION
Corrected the spelling from 'Coover' to 'Cover'