### PR TITLE
Restarting from browse page forces user into get recommendation flow #824

### DIFF
--- a/cypress/e2e/filters-neccc.cy.js
+++ b/cypress/e2e/filters-neccc.cy.js
@@ -15,6 +15,7 @@ describe('Test all possible interactions on the NECCC Crop Calendar Page', () =>
     cy.get("[data-test='state-selector-dropdown-NEW YORK']").click();
     cy.getByTestId('state-selector-dropdown').first().find('input').should('have.value', 'NY');
     cy.assertByTestId('next-btn').first().click();
+    cy.assertByTestId('get-a-recommendation-btn').click();
     cy.assertByTestId('field-location-title');
 
     cy.window().its('store').invoke('dispatch', {

--- a/cypress/e2e/filters-sccc.cy.js
+++ b/cypress/e2e/filters-sccc.cy.js
@@ -15,6 +15,7 @@ describe('Test all possible interactions on the SCCC Crop Calendar Page', () => 
     cy.get("[data-test='state-selector-dropdown-NORTH CAROLINA']").click();
     cy.getByTestId('state-selector-dropdown').first().find('input').should('have.value', 'NC');
     cy.assertByTestId('next-btn').first().click();
+    cy.assertByTestId('get-a-recommendation-btn').click();
     cy.assertByTestId('field-location-title');
 
     cy.window().its('store').invoke('dispatch', {

--- a/cypress/e2e/location-e2e.cy.js
+++ b/cypress/e2e/location-e2e.cy.js
@@ -6,6 +6,7 @@ describe('Testing interactions on location screen', () => {
     cy.assertByTestId('state-selector-dropdown').first().click();
     cy.assertByTestId('state-selector-dropdown-ALABAMA').click();
     cy.assertByTestId('next-btn').first().click();
+    cy.assertByTestId('get-a-recommendation-btn').click();
   });
 
   it('checks if plant-hardiness-dropdown has items equal to mapData.regions array', () => {

--- a/cypress/e2e/user-history.cy.js
+++ b/cypress/e2e/user-history.cy.js
@@ -40,6 +40,7 @@ describe('Test create and import user history records', () => {
     cy.getByTestId('state-selector-dropdown').first().click();
     cy.get("[data-test='state-selector-dropdown-NEW YORK']").click();
     cy.getByTestId('next-btn').first().click();
+    cy.assertByTestId('get-a-recommendation-btn').click();
     // history state should be new and the api call should not been made at this time
     cy.getReduxState().then((state) => {
       const { historyState } = state.userData;
@@ -118,6 +119,7 @@ describe('Test for updating user history', () => {
 
   it('should be able to update history after Location page', () => {
     cy.getByTestId('next-btn').first().click();
+    cy.assertByTestId('get-a-recommendation-btn').click();
 
     cy.window().its('store').invoke('dispatch', {
       type: 'UPDATE_LOCATION',

--- a/src/shared/ProgressButtonsInner.jsx
+++ b/src/shared/ProgressButtonsInner.jsx
@@ -95,10 +95,10 @@ const ProgressButtonsInner = ({
           Please choose what you would like to do next:
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleGetRecommendation} color="primary">
+          <Button onClick={handleGetRecommendation} color="primary" data-test="get-a-recommendation-btn">
             Get a Recommendation
           </Button>
-          <Button onClick={handleBrowseCoverCrops} color="primary">
+          <Button onClick={handleBrowseCoverCrops} color="primary" data-test="browse-cover-crops-btn">
             Browse Cover Crops
           </Button>
         </DialogActions>


### PR DESCRIPTION
Set a dialog asking the users to choose an option that they want to do as the next step after selecting a state, to avoid the default 'Get a Recommendation' flow