### PR TITLE
My selected crops should take you directly to comparison view. Also should we update the button label. #902

### DIFF
--- a/cypress/e2e/filters-neccc.cy.js
+++ b/cypress/e2e/filters-neccc.cy.js
@@ -76,10 +76,10 @@ describe('Test all possible interactions on the NECCC Crop Calendar Page', () =>
       });
   });
 
-  it('should display selected crops number on My Select Crops tab and show corresponding crop cards in My Selected Crops', () => {
+  it('should display selected crops number on My Crops tab and show corresponding crops in My Crops', () => {
     const btnIdx = [0, 1, 2];
     const cropLabels = [];
-    const cardLabels = [];
+    const myCropLabels = [];
 
     btnIdx.forEach((idx) => {
       cy.getByTestId(`cart-btn-${idx}`).click({ force: true });
@@ -109,20 +109,20 @@ describe('Test all possible interactions on the NECCC Crop Calendar Page', () =>
       .first()
       .click()
       .then(() => {
-        cy.get('[data-test^=crop-card-label]').each(($label) => {
+        cy.getByTestId('crop-comparison-table-header').each(($label) => {
           // Ensure the label is visible
           cy.wrap($label).should('be.visible')
             .invoke('text')
             .then((labelText) => {
-              cardLabels.push(flipCoverCropName(labelText));
+              myCropLabels.push(flipCoverCropName(labelText));
               cy.log(`Crop Card Label: ${labelText}`);
             });
         })
           .then(() => {
-            cy.log('=== CARD LABELS===', cardLabels);
-            expect(cropLabels.length).to.equal(cardLabels.length);
+            cy.log('=== CARD LABELS===', myCropLabels);
+            expect(cropLabels.length).to.equal(myCropLabels.length);
             btnIdx.forEach((idx) => {
-              expect(cropLabels[idx].trim().toLowerCase()).to.equal(cardLabels[idx].trim().toLowerCase());
+              expect(cropLabels[idx].trim().toLowerCase()).to.equal(myCropLabels[idx].trim().toLowerCase());
             });
           });
       });
@@ -138,11 +138,6 @@ describe('Test all possible interactions on the NECCC Crop Calendar Page', () =>
       cy.get("[data-test='my selected crops-btn']")
         .first()
         .click({ force: true })
-        .then(() => {
-          cy.get("[data-test='comparison-view-btn']")
-            .should('be.visible')
-            .click();
-        });
 
       const filterTypes = Cypress.env('filterTypes');
       for (let i = 0; i < filterTypes.length; i++) {

--- a/cypress/e2e/filters-sccc.cy.js
+++ b/cypress/e2e/filters-sccc.cy.js
@@ -77,10 +77,10 @@ describe('Test all possible interactions on the SCCC Crop Calendar Page', () => 
       });
   });
 
-  it('should display selected crops number on My Select Crops tab and show corresponding crop cards in My Selected Crops', () => {
+  it('should display selected crops number on My Crops tab and show corresponding crops in My Crops', () => {
     const btnIdx = [0, 1, 2];
     const cropLabels = [];
-    const cardLabels = [];
+    const myCropLabels = [];
 
     btnIdx.forEach((idx) => {
       cy.getByTestId(`cart-btn-${idx}`).click({ force: true });
@@ -110,20 +110,20 @@ describe('Test all possible interactions on the SCCC Crop Calendar Page', () => 
       .first()
       .click()
       .then(() => {
-        cy.get('[data-test^=crop-card-label]').each(($label) => {
+        cy.getByTestId('crop-comparison-table-header').each(($label) => {
           // Ensure the label is visible
           cy.wrap($label).should('be.visible')
             .invoke('text')
             .then((labelText) => {
-              cardLabels.push(flipCoverCropName(labelText));
+              myCropLabels.push(flipCoverCropName(labelText));
               cy.log(`Crop Card Label: ${labelText}`);
             });
         })
           .then(() => {
-            cy.log('=== CARD LABELS===', cardLabels);
-            expect(cropLabels.length).to.equal(cardLabels.length);
+            cy.log('=== CARD LABELS===', myCropLabels);
+            expect(cropLabels.length).to.equal(myCropLabels.length);
             btnIdx.forEach((idx) => {
-              expect(cropLabels[idx].trim().toLowerCase()).to.equal(cardLabels[idx].trim().toLowerCase());
+              expect(cropLabels[idx].trim().toLowerCase()).to.equal(myCropLabels[idx].trim().toLowerCase());
             });
           });
       });
@@ -139,11 +139,6 @@ describe('Test all possible interactions on the SCCC Crop Calendar Page', () => 
       cy.get("[data-test='my selected crops-btn']")
         .first()
         .click({ force: true })
-        .then(() => {
-          cy.get("[data-test='comparison-view-btn']")
-            .should('be.visible')
-            .click();
-        });
 
       const filterTypes = Cypress.env('filterTypes');
       for (let i = 0; i < filterTypes.length; i++) {

--- a/src/pages/CropSelector/CropCalendarView/CropCalendarView.jsx
+++ b/src/pages/CropSelector/CropCalendarView/CropCalendarView.jsx
@@ -460,7 +460,7 @@ const CropCalendarView = ({
                       onClick={() => sortBySelectedCrops()}
                       title={(
                         <>
-                          My List
+                          My Crops
                           {columnSort === 'myList' && <StraightIcon style={{ margin: '0px' }} className={myListSortFlag ? '' : 'rotate180'} />}
                         </>
                         )}

--- a/src/pages/CropSelector/CropTable/CropTable.jsx
+++ b/src/pages/CropSelector/CropTable/CropTable.jsx
@@ -286,7 +286,7 @@ const CropTable = ({
                   onClick={() => sortBySelectedCrops()}
                   title={(
                     <>
-                      My List
+                      My Crops
                       {columnSort === 'myList' && <StraightIcon style={{ margin: '0px' }} className={myListSortFlag ? '' : 'rotate180'} />}
                     </>
                   )}

--- a/src/pages/CropSidebar/CropSidebar.jsx
+++ b/src/pages/CropSidebar/CropSidebar.jsx
@@ -19,10 +19,9 @@ import {
   Chip,
 } from '@mui/material';
 import {
-  Compare, ExpandLess, ExpandMore,
+  ExpandLess, ExpandMore,
 } from '@mui/icons-material';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
-import ListIcon from '@mui/icons-material/List';
 import React, {
   useEffect, useState,
 } from 'react';
@@ -55,7 +54,6 @@ const CropSidebar = ({
   listView,
   from,
   setGrowthWindow,
-  setComparisonView,
   style,
 }) => {
   const dispatchRedux = useDispatch();
@@ -466,22 +464,6 @@ const CropSidebar = ({
   return !loading && (from === 'myCoverCropListStatic') ? (
     <Grid container spacing={3}>
       <Grid item>
-        <PSAButton
-          onClick={() => setComparisonView(false)}
-          selected={!comparisonView}
-          startIcon={<ListIcon style={{ fontSize: 'larger' }} />}
-          buttonType="PillButton"
-          title="CROP LIST"
-        />
-        <PSAButton
-          onClick={() => setComparisonView(true)}
-          selected={comparisonView}
-          startIcon={<Compare style={{ fontSize: 'larger' }} />}
-          buttonType="PillButton"
-          data-test="comparison-view-btn"
-          title="COMPARISON VIEW"
-          className="comparisonViewButton"
-        />
         <ComparisonBar
           filterData={sidebarFilters}
           goals={selectedGoalsRedux?.length > 0 ? selectedGoalsRedux : []}

--- a/src/pages/Header/ToggleOptions/ToggleOptions.jsx
+++ b/src/pages/Header/ToggleOptions/ToggleOptions.jsx
@@ -139,7 +139,7 @@ const ToggleOptions = ({ pathname }) => {
               <span style={{ display: 'block', textAlign: 'center' }}>Selected Crops</span>
             </div>
           ) : (
-            'My Selected Crops'
+            'My Crops'
           )}
         />
       </Badge>

--- a/src/pages/MyCoverCropList/MyCoverCropComparison/MyCoverCropComparisonTable.jsx
+++ b/src/pages/MyCoverCropList/MyCoverCropComparison/MyCoverCropComparisonTable.jsx
@@ -128,6 +128,7 @@ const MyCoverCropComparisonTable = () => {
           transition: 'color 0.3s ease',
         }}
         onClick={() => handleModalOpen(crop)}
+        data-test="crop-comparison-table-header"
       >
         {crop.label}
       </Typography>

--- a/src/pages/MyCoverCropList/MyCoverCropList.jsx
+++ b/src/pages/MyCoverCropList/MyCoverCropList.jsx
@@ -16,13 +16,10 @@ import { PSAButton } from 'shared-react-components/src';
 import MyCoverCropComparisonTable from './MyCoverCropComparison/MyCoverCropComparisonTable';
 import { activateSpeicesSelectorTile } from '../../reduxStore/sharedSlice';
 import pirschAnalytics from '../../shared/analytics';
-import CropCard from '../../components/CropCard/CropCard';
 
-const MyCoverCropList = ({ comparisonView, from }) => {
+const MyCoverCropList = ({ from }) => {
   const dispatchRedux = useDispatch();
-  const comparison = comparisonView || false;
   const history = useHistory();
-  const cropDataRedux = useSelector((stateRedux) => stateRedux.cropData.cropData);
   const stateLabelRedux = useSelector((stateRedux) => stateRedux.mapData.stateLabel);
   const selectedCropIdsRedux = useSelector((stateRedux) => stateRedux.cropData.selectedCropIds);
 
@@ -61,20 +58,12 @@ const MyCoverCropList = ({ comparisonView, from }) => {
              title="Add Crops"
            />
          </Typography>
-        ) : comparison ? (
+        ) : (
           <Box flexDirection="column" display="flex" height="100%" mt={1}>
             <Grid container spacing={2}>
               <MyCoverCropComparisonTable />
             </Grid>
           </Box>
-        ) : (
-          <Grid className="myCropsCards" container spacing={2}>
-            {cropDataRedux.filter((crop) => selectedCropIdsRedux.includes(crop.id)).map((crop, index) => (
-              <Grid item key={index}>
-                <CropCard crop={crop} dispatchRedux={dispatchRedux} />
-              </Grid>
-            ))}
-          </Grid>
         )}
     </>
   );

--- a/src/pages/MyCoverCropList/MyCoverCropListWrapper/MyCoverCropListWrapper.jsx
+++ b/src/pages/MyCoverCropList/MyCoverCropListWrapper/MyCoverCropListWrapper.jsx
@@ -12,7 +12,7 @@ import { setSidebarWidth } from '../../../reduxStore/pageSlice';
 import pirschAnalytics from '../../../shared/analytics';
 
 const MyCoverCropListWrapper = () => {
-  const [comparisonView, setComparisonView] = useState(false);
+  const [comparisonView, setComparisonView] = useState(true);
 
   useEffect(() => {
     pirschAnalytics(comparisonView ? 'Selected Crops: Comparison View' : 'Selected Crops: Crop List');

--- a/src/pages/MyCoverCropList/MyCoverCropListWrapper/MyCoverCropListWrapper.jsx
+++ b/src/pages/MyCoverCropList/MyCoverCropListWrapper/MyCoverCropListWrapper.jsx
@@ -9,14 +9,9 @@ import { useDispatch } from 'react-redux';
 import CropSidebar from '../../CropSidebar/CropSidebar';
 import MyCoverCropList from '../MyCoverCropList';
 import { setSidebarWidth } from '../../../reduxStore/pageSlice';
-import pirschAnalytics from '../../../shared/analytics';
 
 const MyCoverCropListWrapper = () => {
   const [comparisonView, setComparisonView] = useState(true);
-
-  useEffect(() => {
-    pirschAnalytics(comparisonView ? 'Selected Crops: Comparison View' : 'Selected Crops: Crop List');
-  }, [comparisonView]);
 
   const sidebarRef = useRef(null);
   const dispatchRedux = useDispatch();

--- a/src/shared/ProgressButtonsInner.jsx
+++ b/src/shared/ProgressButtonsInner.jsx
@@ -94,7 +94,7 @@ const ProgressButtonsInner = ({
             disabled={isDisabledNext || (progressRedux === 4 && selectedCropIdsRedux.length === 0)}
             buttonType="PillButton"
             data-test={progressRedux === 4 ? 'my selected crops-btn' : 'next-btn'}
-            title={progressRedux === 4 ? 'MY SELECTED CROPS' : 'NEXT'}
+            title={progressRedux === 4 ? 'MY CROPS' : 'NEXT'}
             className="selectedCropsButton"
           />
         </Badge>


### PR DESCRIPTION
1. Removed the 'Crop List' view
2. Removed both of the buttons to get the user directly into the comparison view
3. Renamed the label from 'My Selected Crops' and 'My List' to 'My Crops'