### PR TITLE
Update wccc planting season filter to use api response data

### DIFF
--- a/src/pages/CropSidebar/CropSidebar.jsx
+++ b/src/pages/CropSidebar/CropSidebar.jsx
@@ -188,9 +188,9 @@ const CropSidebar = ({
       if (councilShorthandRedux === 'WCCC') {
         match = false;
         const seasonMatch = selectedSeasonRedux.length === 0
-        || crop.plantingDates.some((date) => selectedSeasonRedux.some((season) => date.label.includes(season)));
+          || crop.plantingDates.some((date) => selectedSeasonRedux.some((season) => date.label.includes(season)));
         const firstGoalRatingLargerThanTwo = selectedGoalsRedux.length === 0
-        || Number(crop.goals.filter((g) => g.label === selectedGoalsRedux[0])[0]?.values[0]?.value) > 2;
+          || Number(crop.goals.filter((g) => g.label === selectedGoalsRedux[0])[0]?.values[0]?.value) > 2;
         if (seasonMatch && firstGoalRatingLargerThanTwo) {
           match = true;
         }

--- a/src/pages/GoalsSelector/GoalsSelector.jsx
+++ b/src/pages/GoalsSelector/GoalsSelector.jsx
@@ -38,9 +38,7 @@ const GoalsSelector = () => {
   const stateIdRedux = useSelector((stateRedux) => stateRedux.mapData.stateId);
   const queryStringRedux = useSelector((stateRedux) => stateRedux.sharedData.queryString);
   const apiBaseUrlRedux = useSelector((stateRedux) => stateRedux.sharedData.apiBaseUrl);
-  const selectedGoalsRedux = [...useSelector(
-    (stateRedux) => stateRedux.goalsData.selectedGoals,
-  )].reverse();
+  const selectedGoalsRedux = useSelector((stateRedux) => stateRedux.goalsData.selectedGoals);
   const councilShorthandRedux = useSelector((stateRedux) => stateRedux.mapData.councilShorthand);
 
   const selectedSeasonRedux = useSelector((stateRedux) => stateRedux.terminationData.selectedSeason);

--- a/src/pages/GoalsSelector/GoalsSelector.jsx
+++ b/src/pages/GoalsSelector/GoalsSelector.jsx
@@ -21,6 +21,13 @@ import {
   setIrrigationFilter,
 } from '../../reduxStore/filterSlice';
 
+const seasons = ['Dormant/Frost', 'Early Spring', 'Spring', 'Early Summer', 'Summer',
+  'Late Summer', 'Late Summer / Early Fall', 'Fall', 'Winter'];
+
+const durationTypes = ['Annual', 'Perennial'];
+
+const irrigationType = ['Rainfed', 'Irrigated'];
+
 const GoalsSelector = () => {
   // theme vars
   const theme = useTheme();
@@ -44,12 +51,7 @@ const GoalsSelector = () => {
 
   // useState vars
   const [allGoals, setAllGoals] = useState([]);
-
-  const seasons = ['Spring', 'Summer', 'Fall', 'Winter'];
-
-  const durationTypes = ['Annual', 'Perennial'];
-
-  const irrigationType = ['Rainfed', 'Irrigated'];
+  const [plantingSeasons, setPlantingSeasons] = useState([]);
 
   const handleSelectedSeason = (season) => {
     if (selectedSeasonRedux.includes(season)) {
@@ -76,6 +78,9 @@ const GoalsSelector = () => {
     callCoverCropApi(
       `https://${apiBaseUrlRedux}.covercrop-selector.org/v1/states/${stateIdRedux}/goals?${queryStringRedux}`,
     ).then((data) => {
+      if (councilShorthandRedux === 'WCCC' && data.plantingSeasons) {
+        setPlantingSeasons(data.plantingSeasons);
+      }
       setAllGoals(data.data);
     });
     pirschAnalytics('Visited Page', { meta: { visited: 'Goals' } });
@@ -179,41 +184,48 @@ const GoalsSelector = () => {
             && (
               <>
                 {/* Planting Season */}
-                <Grid container sx={{ m: '1rem' }}>
-                  <Grid item xs={12}>
-                    <Typography variant="h5" align="center">
-                      Planting Season
-                    </Typography>
+                {plantingSeasons.length > 0 && (
+                  <Grid container sx={{ m: '1rem' }}>
+                    <Grid item xs={12}>
+                      <Typography variant="h5" align="center">
+                        Planting Season
+                      </Typography>
+                    </Grid>
+                    <Grid
+                      item
+                      xs={12}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexWrap: 'wrap',
+                      }}
+                    >
+                      {seasons.map((season, i) => {
+                        if (plantingSeasons.includes(season)) {
+                          return (
+                            <Chip
+                              key={season}
+                              label={season}
+                              id={(`season${i}`)}
+                              clickable
+                              style={{ margin: '0.3rem' }}
+                              sx={{
+                                '&:focus': {
+                                  boxShadow: '0 0 0 2px black',
+                                  maxWidth: !isLargeScreen ? '45%' : 'auto',
+                                },
+                              }}
+                              onClick={() => handleSelectedSeason(season)}
+                              color={selectedSeasonRedux.includes(season) ? 'primary' : 'secondary'}
+                            />
+                          );
+                        }
+                        return null;
+                      })}
+                    </Grid>
                   </Grid>
-                  <Grid
-                    item
-                    xs={12}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      flexWrap: 'wrap',
-                    }}
-                  >
-                    {seasons.map((season, i) => (
-                      <Chip
-                        key={season}
-                        label={season}
-                        id={(`season${i}`)}
-                        clickable
-                        style={{ margin: '0.3rem' }}
-                        sx={{
-                          '&:focus': {
-                            boxShadow: '0 0 0 2px black',
-                            maxWidth: !isLargeScreen ? '45%' : 'auto',
-                          },
-                        }}
-                        onClick={() => handleSelectedSeason(season)}
-                        color={selectedSeasonRedux.includes(season) ? 'primary' : 'secondary'}
-                      />
-                    ))}
-                  </Grid>
-                </Grid>
+                )}
                 {/* Will you irrigate */}
                 <Grid container sx={{ m: '1rem' }}>
                   <Grid item xs={12}>

--- a/src/pages/GoalsSelector/GoalsSelector.jsx
+++ b/src/pages/GoalsSelector/GoalsSelector.jsx
@@ -74,7 +74,8 @@ const GoalsSelector = () => {
 
   useEffect(() => {
     callCoverCropApi(
-      `https://${apiBaseUrlRedux}.covercrop-selector.org/v1/states/${stateIdRedux}/goals?${queryStringRedux}`,
+      `https://${apiBaseUrlRedux}.covercrop-selector.org/v1/states/${stateIdRedux}/goals?`
+      + `${councilShorthandRedux === 'WCCC' ? 'seasons=true&' : ''}${queryStringRedux}`,
     ).then((data) => {
       if (councilShorthandRedux === 'WCCC' && data.plantingSeasons) {
         setPlantingSeasons(data.plantingSeasons);

--- a/src/reduxStore/goalSlice.jsx
+++ b/src/reduxStore/goalSlice.jsx
@@ -39,7 +39,7 @@ const goalsReducer = (state = initialState, action = null) => {
     case 'ADD_SELECTED_GOALS':
       return {
         ...state,
-        selectedGoals: [action.payload.value, ...state.selectedGoals],
+        selectedGoals: [...state.selectedGoals, action.payload.value],
       };
 
     case 'SET_GOALS_REDUX':


### PR DESCRIPTION
- Updated wccc `Planting Season` filter, use api response to generate possible options.
- Updated goal selection order to prevent unnecessary useEffects.

This pr is based on #918