### PR TITLE
Remove old URL references to http://covercrop.tools/ #978

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -9,12 +9,12 @@ If you have personal support or setup questions the best way to ask those are by
 
 ### Bug Reports
 
-Submit a bug via our [feedback form](https://covercrop.tools/feedback). When appropriate, the project manager, program manager, or development team will escalate it, creating an issue.
+Submit a bug via our [feedback form](https://covercrop-selector.org/feedback). When appropriate, the project manager, program manager, or development team will escalate it, creating an issue.
 When reporting a bug make sure to include information about which browser and operating system you are on as well as the necessary steps to reproduce the issue. If possible please include a screenshot.
 
 ### Feature Requests
 
-Submit a feature request via our [feedback form](https://covercrop.tools/feedback). When appropriate, the program manager will escalate it, creating an issue.
+Submit a feature request via our [feedback form](https://covercrop-selector.org/feedback). When appropriate, the program manager will escalate it, creating an issue.
 When requesting a feature include sketches and pseudo code if possible.
 
 ### Pull Requests
@@ -27,7 +27,7 @@ When requesting a feature include sketches and pseudo code if possible.
 
 ### Cover Crop Data Feedback
 
-Submit Cover Crop Data feedback via our [feedback form](https://covercrop.tools/feedback). When appropriate, the project manager or program manager will update the data set and push updates to the dataset.
+Submit Cover Crop Data feedback via our [feedback form](https://covercrop-selector.org/feedback). When appropriate, the project manager or program manager will update the data set and push updates to the dataset.
 
 ### Escalating Bugs and Features to Issues
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "decision-support-tool",
   "version": "1.0.0",
   "private": true,
-  "homepage": "https://covercrop.tools/",
+  "homepage": "https://covercrop-selector.org/",
   "dependencies": {
     "@auth0/auth0-react": "^2.2.0",
     "@babel/runtime": "^7.25.6",

--- a/src/pages/License/MITLicenseText/MITLicenseText.jsx
+++ b/src/pages/License/MITLicenseText/MITLicenseText.jsx
@@ -61,7 +61,7 @@ const MITLicenseText = ({ styles = true, aboutPage = false }) => {
         <Grid item xs={12}>
           <Typography variant="body1">
             The cover crop data is part of NECCC Cover Crop Decision Support Tools project
-            (https://covercrop.tools). The data files and their contents licensed under the terms of
+            (https://covercrop-selector.org). The data files and their contents licensed under the terms of
             MIT License. You may use, copy, modify and redistribute all files included in this
             distribution, individually or in aggregate, subject to the terms and conditions of the
             MIT license. See


### PR DESCRIPTION
Changed the url from 'https://covercrop.tools/'  to ' https://covercrop-selector.org/'